### PR TITLE
Improve user notifications when somebody has left a group (#1619)

### DIFF
--- a/src/locales/locale-en.json
+++ b/src/locales/locale-en.json
@@ -603,7 +603,8 @@
     "NEW_PLACE": "{placeName} has been created",
     "USER_BECAME_EDITOR": "{userName} gained editing permissions",
     "VOTING_ENDS_SOON": "Voting ends soon, don't forget to participate!",
-    "YOU_BECAME_EDITOR": "You gained editing permissions"
+    "YOU_BECAME_EDITOR": "You gained editing permissions",
+    "MEMBER_LEFT": "{userName} has left the group"
   },
   "NOTIFICATION_BELLS_LIST": {
     "NO_ITEMS": "We currently don't have notifications for you.",

--- a/src/locales/locale-pt_BR.json
+++ b/src/locales/locale-pt_BR.json
@@ -603,7 +603,8 @@
     "NEW_PLACE": "{placeName} has been created",
     "USER_BECAME_EDITOR": "{userName} gained editing permissions",
     "VOTING_ENDS_SOON": "Voting ends soon, don't forget to participate!",
-    "YOU_BECAME_EDITOR": "You gained editing permissions"
+    "YOU_BECAME_EDITOR": "You gained editing permissions",
+    "MEMBER_LEFT": "{userName} saiu do grupo"
   },
   "NOTIFICATION_BELLS_LIST": {
     "NO_ITEMS": "We currently don't have notifications for you.",

--- a/src/notifications/components/notificationConfig.js
+++ b/src/notifications/components/notificationConfig.js
@@ -39,6 +39,7 @@ function getMessageParams (type, context) {
     case 'conflict_resolution_created':
     case 'conflict_resolution_continued':
     case 'conflict_resolution_decided':
+    case 'member_left':
       return {
         userName: context.user && context.user.displayName,
       }
@@ -52,6 +53,8 @@ function getIcon (type, context) {
     case 'activity_enabled':
     case 'application_accepted':
       return 'fas fa-check'
+    case 'member_left':
+      return 'fas fa-user-minus'
     case 'activity_disabled':
     case 'application_declined':
     case 'conflict_resolution_you_were_removed':
@@ -94,6 +97,7 @@ function getRouteTo (type, { group, user, place, activity, issue } = {}) {
     case 'user_became_editor':
     case 'invitation_accepted':
     case 'new_member':
+    case 'member_left':
       return user && { name: 'userInGroup', params: { userId: user.id, groupId: group.id } }
     case 'you_became_editor': // TODO show information about editing permissions
     case 'application_accepted':


### PR DESCRIPTION
* added notification type for member_left
* added icon fa-user-minus for notification item
* links and username reflect link to user profile and userName property

Closes #1619

## What does this PR do?

There's no bell notifications when an user has left the group, and also the history does not correctly return the user's information. On this PR the goal is to resolve the first issue whereas on the PR(https://github.com/yunity/karrot-backend/pull/1104) the logic to support this functionality was added.

## Links to related issues

## Checklist

- [ ] added a test, or explain why one is not needed/possible...
  - I believe a test is needed, however, my knowledge of the quasar framework is a bit limited to write them by myself. If one could point me in the right direction of finding documentation and informations about the technique needed, I'd be glad to write them.

- [x] no unrelated changes
- [x] asked someone for a code review
- [ ] joined [chat.foodsaving.world/channel/karrot-dev](https://chat.foodsaving.world/channel/karrot-dev)
- [ ] added an entry to CHANGELOG.md (description, pull request link, username(s))
- [x] tried out on a mobile device (does everything work as expected on a smaller screen?)