### PR TITLE
Update community forum url and de-foodsaving-ify a bit more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,7 +138,7 @@ Please document your changes in this format:
 - Display number of total group members on top of member list [#2149] @djahnie
 
 ### Changed
-- Improve activity history display to show activity information more clearly [#2151] from [suggestion](https://community.foodsaving.world/t/how-do-you-handle-late-drop-outs-from-pickups/213/10) @nicksellen
+- Improve activity history display to show activity information more clearly [#2151] from [suggestion](https://community.karrot.world/t/how-do-you-handle-late-drop-outs-from-pickups/213/10) @nicksellen
 - Only show pull-to-refresh in app @tiltec
 - Sort feedback by activity date instead of feedback date [#2157] [#2161] [#1044](https://github.com/yunity/karrot-backend/pull/1044) @nicksellen
 

--- a/README.md
+++ b/README.md
@@ -79,13 +79,11 @@ If you want to use an eslint plugin for your editor, please keep in mind that yo
 
 ## Start contributing?
 
-We have a forum for Karrot developers and users at https://community.foodsaving.world/c/karrot.
+We have a forum for Karrot developers and users at https://community.karrot.world.
 
-If you are interested in contributing, you may -
-- join us in the [#karrot-dev chatroom on chat.karrot.world](https://chat.karrot.world/channel/karrot-dev)
-- join our weekly call; previous minutes can be found in [this thread](https://community.foodsaving.world/t/weekly-call-about-karrot-development/289)
+If you are interested in contributing, check out our [onboarding guide](https://community.karrot.world/t/how-to-get-involved-onboarding-into-the-karrot-team/661).
 
-The most important information is written down in our [contribution guidelines](CONTRIBUTE.md).
+The most important dev information is written down in our [contribution guidelines](CONTRIBUTE.md).
 
 The [backend](https://github.com/yunity/karrot-backend) is developed to support this frontend. If you find a bug or miss something in the API, please file an issue in the backend repository.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Karrot Roadmap
 
-## General Direction as of [2021-04-05](https://community.foodsaving.world/t/roadmap-meeting/410/4)
+## General Direction as of [2021-04-05](https://community.karrot.world/t/roadmap-meeting/410/4)
 
 - Refining UX and some user testing
 - Finish testing prototype for community governance features. Begin implementation?
@@ -43,7 +43,7 @@ We want to work on this in mid-term future. We need to think about it more befor
 
 - [Choice between "wall" or "activities/pickups" as the default page for a place](https://github.com/yunity/karrot-frontend/issues/1703)
 - [Better handling for much wanted pickups](https://github.com/yunity/karrot-frontend/issues/1242)
-- [Applicant trial activity](https://community.foodsaving.world/t/applicant-trial-pickup-proposal/575/)
+- [Applicant trial activity](https://community.karrot.world/t/applicant-trial-pickup-proposal/575/)
 - [Improve notifications for place conversations](https://github.com/yunity/karrot-frontend/issues/2342)
 
 [View issues](https://github.com/yunity/karrot-frontend/milestone/9)

--- a/docs/src/features/groups.md
+++ b/docs/src/features/groups.md
@@ -2,7 +2,7 @@
 
 Groups are at the heart of Karrot. Each group is independent from the rest and will usually represent an in-person community of people. They normally have their own organisational name and structure.
 
-They are not part of the karrot organisation, they just use karrot. Ideally one of more of the community members participate in our [community forum](https://community.foodsaving.world/), or via [chat.karrot.world/channel/karrot-dev](https://chat.karrot.world/channel/karrot-dev)/[GitHub](https://github.com/yunity/karrot-frontend)/etc.
+They are not part of the karrot organisation, they just use karrot. Ideally one of more of the community members participate in our [community forum](https://community.karrot.world/), or via [chat.karrot.world/channel/karrot-dev](https://chat.karrot.world/channel/karrot-dev)/[GitHub](https://github.com/yunity/karrot-frontend)/etc.
 
 ## Group Gallery
 

--- a/public/maintenance.html
+++ b/public/maintenance.html
@@ -71,7 +71,7 @@
   <div class="message">
     <h2>Sorry, we are doing some maintenance right now</h2>
     <h3>We will be back online soon!</h3>
-    <p>Why not come and hang out in our <a href="https://community.foodsaving.world/">community&nbsp;forum</a> while you wait?</p>
+    <p>Why not come and hang out in our <a href="https://community.karrot.world/">community&nbsp;forum</a> while you wait?</p>
   </div>
 </div>
 </body>

--- a/src-cordova/config/dev/config.xml
+++ b/src-cordova/config/dev/config.xml
@@ -2,8 +2,8 @@
 <widget id="world.karrot.dev" version="9.5.1" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>Karrot Dev</name>
     <description>Karrot is a free and open-source tool for grassroots initiatives and groups of people that want to coordinate face-to-face activities on a local, autonomous and voluntary basis.</description>
-    <author email="karrot@foodsaving.world" href="https://foodsaving.world">
-        Foodsaving World Team
+    <author email="info@karrot.world" href="https://karrot.world">
+        Karrot Team
     </author>
     <icon src="config/current/carrot_logo_144x144.png" />
     <content src="index.html" />

--- a/src-cordova/config/prod/config.xml
+++ b/src-cordova/config/prod/config.xml
@@ -2,8 +2,8 @@
 <widget id="world.karrot" version="9.5.1" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>Karrot</name>
     <description>Karrot is a free and open-source tool for grassroots initiatives and groups of people that want to coordinate face-to-face activities on a local, autonomous and voluntary basis.</description>
-    <author email="karrot@foodsaving.world" href="https://foodsaving.world">
-        Foodsaving World Team
+    <author email="info@karrot.world" href="https://karrot.world">
+        Karrot Team
     </author>
     <icon src="config/current/carrot_logo_144x144.png" />
     <content src="index.html" />

--- a/src-cordova/playstoreAssets/en-US/listing/fullDescription.txt
+++ b/src-cordova/playstoreAssets/en-US/listing/fullDescription.txt
@@ -1,22 +1,3 @@
-Foodsaving: The act of making food that was already intended to be thrown into the bin available for human consumption again.
+Karrot is a free and open-source tool for grassroots initiatives and groups of people that want to coordinate face-to-face activities on a local, autonomous and voluntary basis.
 
-This can be done most efficiently through cooperations whith stores. The foodsavers and the store agree on clear times at which food can be picked up free of charge. The saved food will then be distributed to people who can make use of it.
-
-To make the lives of foodsavers as easy as possible Karrot provides many functionalities for pickup organization, such as:
-
-- push notifications
-- group wall
-- private messaging
-- store pages with description and location
-- map to display store locations
-- one-time or recurring pickup dates
-- individual number of slots for each pickup
-- pickup chats
-- full translation support via transifex
-- activity history for full transparency
-- pickup feedback option
-- application process for potential group members
-- approval system for new group members
-- community forum activity notifier
-
-Karrot is in active development and thus constantly improved. It does not incorporate standard admin roles but will find progressive ways of automatically adjusting hierarchies that reflect a group's actual responsibility structure. We already took the first steps in this direction with the application and approval systems, but it's far from being finished.
+It is designed in ways to enable community-building and support a more transparent, democratic and participatory governance of your group.

--- a/src-cordova/playstoreAssets/en-US/listing/shortDescription.txt
+++ b/src-cordova/playstoreAssets/en-US/listing/shortDescription.txt
@@ -1,1 +1,1 @@
-The free and open source pickup organizer for foodsaving groups
+Karrot is a free and open-source tool for grassroots initiatives and groups of people that want to coordinate face-to-face activities on a local, autonomous and voluntary basis.

--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -7795,7 +7795,7 @@ exports[`Storyshots KAbout KAbout 1`] = `
   <div class="k-logo-container row no-wrap items-center"><a class="logo self-start"><img src="test-file-stub" alt="karrot logo"></a>
     <h4 class="col q-ma-none q-pl-md"></h4>
   </div>
-  <div class="q-mt-md q-list"><a tabindex="0" rel="noopener noreferrer" href="https://community.foodsaving.world/t/how-to-get-involved-onboarding-into-the-karrot-team/661" target="_blank" class="q-item q-item-type row no-wrap q-item--clickable q-link cursor-pointer q-focusable q-hoverable">
+  <div class="q-mt-md q-list"><a tabindex="0" rel="noopener noreferrer" href="https://community.karrot.world/t/how-to-get-involved-onboarding-into-the-karrot-team/661" target="_blank" class="q-item q-item-type row no-wrap q-item--clickable q-link cursor-pointer q-focusable q-hoverable">
       <div tabindex="-1" class="q-focus-helper"></div>
       <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="fas fa-users q-icon notranslate"> </i></div>
       <div class="q-item__section column q-item__section--main justify-center">
@@ -9816,7 +9816,7 @@ exports[`Storyshots Settings Page Default 1`] = `
       </div>
     </div>
     <div class="q-card__section q-card__section--vert">
-      <div class="edit-box row justify-end"><button tabindex="0" type="button" role="button" title="Switch language" class="q-btn q-btn-item non-selectable no-outline k-locale-select q-btn--standard q-btn--rectangle q-btn--actionable q-focusable q-hoverable q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="fas fa-globe fa-fw q-icon notranslate"> </i> 
+      <div class="edit-box row justify-end"><button tabindex="0" type="button" role="button" title="Switch language" class="q-btn q-btn-item non-selectable no-outline k-locale-select q-btn--standard q-btn--rectangle q-btn--actionable q-focusable q-hoverable q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="fas fa-globe fa-fw q-icon notranslate"> </i>
     English
    <!----></span></span></button></div>
     </div>

--- a/src/base/components/KAbout.vue
+++ b/src/base/components/KAbout.vue
@@ -91,7 +91,7 @@
       <QItem
         tag="a"
         rel="noopener noreferrer"
-        href="mailto:karrot@foodsaving.world"
+        href="mailto:info@karrot.world"
       >
         <QItemSection side>
           <QIcon name="fas fa-fw fa-envelope" />
@@ -99,7 +99,7 @@
 
         <QItemSection>
           <QItemLabel>
-            karrot@foodsaving.world
+            info@karrot.world
           </QItemLabel>
         </QItemSection>
       </QItem>

--- a/src/base/components/KAbout.vue
+++ b/src/base/components/KAbout.vue
@@ -19,7 +19,7 @@
       <QItem
         tag="a"
         rel="noopener noreferrer"
-        href="https://community.foodsaving.world/t/how-to-get-involved-onboarding-into-the-karrot-team/661"
+        href="https://community.karrot.world/t/how-to-get-involved-onboarding-into-the-karrot-team/661"
         target="_blank"
       >
         <QItemSection side>

--- a/src/base/pages/Landing.vue
+++ b/src/base/pages/Landing.vue
@@ -165,7 +165,7 @@
               <a
                 slot="forum"
                 v-t="'ABOUT_KARROT.LINKS.FORUM'"
-                href="https://community.foodsaving.world"
+                href="https://community.karrot.world"
               />
               <a
                 slot="chat"

--- a/src/boot/helloDeveloper.js
+++ b/src/boot/helloDeveloper.js
@@ -12,7 +12,7 @@ export default async () => {
         Do you want to come and help us build our distributed, global grassroots movement against food waste?
 
         %c
-        Community forum → https://community.foodsaving.world
+        Community forum → https://community.karrot.world
                 Project → https://foodsaving.world
                    Code → https://github.com/yunity/karrot-frontend
                    Chat → https://chat.karrot.world/channel/karrot-dev

--- a/src/boot/helloDeveloper.js
+++ b/src/boot/helloDeveloper.js
@@ -9,13 +9,12 @@ export default async () => {
         Oh, hey there developer! 🙂
 
         %c
-        Do you want to come and help us build our distributed, global grassroots movement against food waste?
+        Do you want to come and help us build our tool for grassroots initiatives?
 
         %c
-        Community forum → https://community.karrot.world
-                Project → https://foodsaving.world
-                   Code → https://github.com/yunity/karrot-frontend
-                   Chat → https://chat.karrot.world/channel/karrot-dev
+            Forum → https://community.karrot.world
+             Code → https://github.com/yunity/karrot-frontend
+             Chat → https://chat.karrot.world/channel/karrot-dev
       `.trim().replace(/^ {6}/gm, '').replace(/%c\n/g, '%c'),
       style({
         ...sansSerif,

--- a/src/communityFeed/api/communityFeed.js
+++ b/src/communityFeed/api/communityFeed.js
@@ -19,7 +19,7 @@ export default {
         ...topic,
         createdAt: new Date(topic.createdAt),
         lastPostedAt: new Date(topic.lastPostedAt),
-        link: `https://community.foodsaving.world/t/${topic.slug}/${topic.id}`,
+        link: `https://community.karrot.world/t/${topic.slug}/${topic.id}`,
         lastPosterAvatar: backend + '/community_proxy' + lastPoster.avatarTemplate.split('{size}').join('45'),
         lastPosterUsername: lastPoster.username,
       }

--- a/src/communityFeed/components/CommunityFeed.vue
+++ b/src/communityFeed/components/CommunityFeed.vue
@@ -43,7 +43,7 @@
               <i18n path="COMMUNITY_FEED.HEADER">
                 <a
                   slot="community"
-                  href="https://community.foodsaving.world"
+                  href="https://community.karrot.world"
                   target="_blank"
                   rel="noopener"
                   style="text-decoration: underline"

--- a/src/issues/components/ConflictSetup.vue
+++ b/src/issues/components/ConflictSetup.vue
@@ -41,7 +41,7 @@
           <p>{{ $t('CONFLICT.STEPPER3d', { votingDuration: currentGroup && currentGroup.issueVotingDurationDays }) }}</p>
           <a
             v-t="'CONFLICT.FIND_OUT_MORE'"
-            href="https://community.foodsaving.world/t/how-does-the-conflict-resolution-feature-work/254"
+            href="https://community.karrot.world/t/how-does-the-conflict-resolution-feature-work/254"
             target="_blank"
             rel="noopener"
             style="text-decoration: underline"

--- a/src/issues/components/IssueVote.vue
+++ b/src/issues/components/IssueVote.vue
@@ -22,7 +22,7 @@
               <p v-t="'CONFLICT.INFO.MESSAGE'" />
               <a
                 v-t="'CONFLICT.FIND_OUT_MORE'"
-                href="https://community.foodsaving.world/t/how-does-the-conflict-resolution-feature-work/254/3"
+                href="https://community.karrot.world/t/how-does-the-conflict-resolution-feature-work/254/3"
                 target="_blank"
                 rel="noopener"
                 style="text-decoration: underline"

--- a/src/locales/locale-en.json
+++ b/src/locales/locale-en.json
@@ -251,7 +251,7 @@
   },
   "COMMUNITY_FEED": {
     "HEADER": "Updates from the {community}",
-    "HEADER_LINK": "foodsaving worldwide community",
+    "HEADER_LINK": "Karrot community",
     "KARROT_DISCUSSION": "Discussions about Karrot",
     "LAST_UPDATED": "Last updated {relativeDate}"
   },

--- a/src/sidenav/components/SidenavGroupUI.vue
+++ b/src/sidenav/components/SidenavGroupUI.vue
@@ -150,7 +150,7 @@ export default {
           description: this.$t('GROUP.PICKUPS_TO_ACTIVITIES_DESCRIPTION'),
           link: {
             text: this.$t('BUTTON.READ_MORE'),
-            href: 'https://community.foodsaving.world/t/what-are-activity-types-in-karrot/563',
+            href: 'https://community.karrot.world/t/what-are-activity-types-in-karrot/563',
           },
         },
         icon: this.$icon('activity'),

--- a/src/users/components/TrustInfo.vue
+++ b/src/users/components/TrustInfo.vue
@@ -20,7 +20,7 @@
           <p v-t="'USERDATA.TRUST_INFO.MESSAGE'" />
           <a
             v-t="'USERDATA.TRUST_INFO.LINK'"
-            href="https://community.foodsaving.world/t/karrot-trust-system-and-user-levels/108"
+            href="https://community.karrot.world/t/karrot-trust-system-and-user-levels/108"
             target="_blank"
             rel="noopener"
             style="text-decoration: underline"

--- a/src/users/pages/Profile.vue
+++ b/src/users/pages/Profile.vue
@@ -163,7 +163,7 @@
           <p>
             <a
               v-t="'CONFLICT.FIND_OUT_MORE'"
-              href="https://community.foodsaving.world/t/how-does-the-conflict-resolution-feature-work/254"
+              href="https://community.karrot.world/t/how-does-the-conflict-resolution-feature-work/254"
               target="_blank"
               rel="noopener"
               style="text-decoration: underline"


### PR DESCRIPTION
## What does this PR do?

Now the community forum moved from community.foodsaving.world to community.karrot.world, the references here need to be updated. I also took the opportunity to switch out a few references to foodsaving.

## Links to related issues

## Checklist

- [ ] added a test, or explain why one is not needed/possible...
- [ ] no unrelated changes
- [ ] asked someone for a code review
- [ ] joined [chat.foodsaving.world/channel/karrot-dev](https://chat.foodsaving.world/channel/karrot-dev)
- [ ] added an entry to CHANGELOG.md (description, pull request link, username(s))
- [ ] tried out on a mobile device (does everything work as expected on a smaller screen?)