### PR TITLE
Add "Previous 12 months" to statistics time period

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Please document your changes in this format:
 - API for revoking trust @pogopaule [#1133](https://github.com/karrot-dev/karrot-backend/pull/1133)
 - API for calendar subscriptions @amengsk [#1132](https://github.com/karrot-dev/karrot-backend/pull/1132)
 - add ics export for activities @amengsk @larzon83 [#2321]
+- Add "Previous 12 months" to statistics time period [#2445]
 
 ### Changed
 - amount-picker: improve UX of weight slider limits @larzon83 @layla19 @dpaque @pogopaule [#2348]

--- a/src/statistics/pages/ActivityHistoryStatistics.vue
+++ b/src/statistics/pages/ActivityHistoryStatistics.vue
@@ -197,6 +197,10 @@ export default {
           value: '6months',
         },
         {
+          label: this.$t('STATISTICS.FILTER_TIME_PREVIOUS_MONTHS', { count: 12 }),
+          value: '12months',
+        },
+        {
           label: this.$t('STATISTICS.FILTER_TIME_FOREVER'),
           value: null,
           disable: this.hasUserFilter,
@@ -262,6 +266,10 @@ export default {
         case '6months':
           return {
             dateAfter: subMonths(now, 6),
+          }
+        case '12months':
+          return {
+            dateAfter: subMonths(now, 12),
           }
         case null:
           return {}

--- a/src/statistics/pages/ActivityHistoryStatistics.vue
+++ b/src/statistics/pages/ActivityHistoryStatistics.vue
@@ -199,6 +199,7 @@ export default {
         {
           label: this.$t('STATISTICS.FILTER_TIME_PREVIOUS_MONTHS', { count: 12 }),
           value: '12months',
+          disable: this.hasUserFilter,
         },
         {
           label: this.$t('STATISTICS.FILTER_TIME_FOREVER'),


### PR DESCRIPTION
Closes #2445

## What does this PR do?
Adds the time period "Previous 12 months" to the selection menu on the statistics page.

## Links to related issues

## Checklist

- [ ] added a test, or explain why one is not needed/possible...
- [ ] no unrelated changes
- [ ] asked someone for a code review
- [ ] joined [#karrot:matrix.org](https://matrix.to/#/#karrot:matrix.org)
- [ ] added an entry to CHANGELOG.md (description, pull request link, username(s))
- [ ] tried out on a mobile device (does everything work as expected on a smaller screen?)
