### PR TITLE
Add day of week filter for activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Please document your changes in this format:
 - Improve calculation of map bounds on group gallery @nicksellen [#2333]
 - main-layout: use scaled down background-image @larzon83 [#2371]
 - Use roboto font in latin-ext variant @nicksellen [#2345]
+- Add day of week filter for activities [#2310]
 
 ### Fixed
 - Place statistics feedback weight should be summed @nicksellen [#1137](https://github.com/karrot-dev/karrot-backend/pull/1137)

--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -1165,10 +1165,7 @@ exports[`Storyshots ActivityItem started 1`] = `
 exports[`Storyshots ActivityList Default 1`] = `
 <div>
   <!---->
-  <div class="row no-wrap items-center justify-end q-px-sm q-mt-sm">
-    <!---->
-    <!---->
-  </div>
+  <!---->
   <div class="full-width text-center generic-padding" style="display:none;"><svg focusable="false" fill="currentColor" width="40" height="40" viewBox="0 0 120 30" xmlns="http://www.w3.org/2000/svg" class="q-spinner">
       <circle cx="15" cy="15" r="15">
         <animate attributeName="r" from="15" to="15" begin="0s" dur="0.8s" values="15;9;15" calcMode="linear" repeatCount="indefinite"></animate>
@@ -1183,227 +1180,20 @@ exports[`Storyshots ActivityList Default 1`] = `
         <animate attributeName="fill-opacity" from="1" to="1" begin="0s" dur="0.8s" values="1;.5;1" calcMode="linear" repeatCount="indefinite"></animate>
       </circle>
     </svg></div>
-  <!---->
-  <div class="q-infinite-scroll">
-    <div class="q-px-sm q-pt-lg full-width text-center text-bold" style="color:rgba(0, 0, 0, 0.7);">
-      Sun, December 24
-    </div>
-    <div class="q-card">
-      <div class="no-padding content q-card__section q-card__section--vert isEmpty">
-        <div class="content-inner">
-          <div class="row no-wrap items-start justify-between">
-            <div><strong class="featured-text">
-            12:00 PM
-            <!----></strong>
-              Sunday, December 24, 2017
-            </div> <i aria-hidden="true" role="presentation" title="" class="q-ml-sm q-icon notranslate" style="font-size:18px;top:1px;"></i>
-          </div>
-          <!---->
-          <!---->
-          <!---->
-          <div class="q-mt-sm q-mb-none full-width">
-            <div class="row justify-start"><object tabindex="-1" type="text/html" data="about:blank" aria-hidden="true" style="display:block;position:absolute;top:0;left:0;right:0;bottom:0;height:100%;width:100%;overflow:hidden;pointer-events:none;z-index:-1;"></object>
-              <!---->
-              <div class="user-slot-wrapper active" style="width:36px;height:36px;">
-                <div title="Join" class="show-picture-on-hover">
-                  <div class="wrapper" style="width:36px;height:36px;">
-                    <div text="User 11" seed="11" class="randomArt fill"></div>
-                  </div>
-                </div>
-              </div>
-              <div class="user-slot-wrapper greyedOut" style="width:36px;height:36px;"></div>
-              <div class="user-slot-wrapper greyedOut" style="width:36px;height:36px;"></div>
-              <div class="user-slot-wrapper greyedOut" style="width:36px;height:36px;"></div>
-              <div class="user-slot-wrapper greyedOut" style="width:36px;height:36px;"></div>
-              <div class="user-slot-wrapper greyedOut" style="width:36px;height:36px;"></div>
-              <div class="emptySlots" style="width:36px;height:36px;">
-                <div></div> <span>+ 4</span>
-                <!---->
-                <!---->
-              </div>
-            </div>
-            <!---->
-            <!---->
-          </div>
-        </div>
+  <div class="q-pa-md">
+    <div role="alert" class="q-banner row items-center bg-white">
+      <div class="q-banner__avatar col-auto row items-center self-start"><i aria-hidden="true" role="presentation" class="fas fa-info-circle q-icon notranslate text-grey"> </i></div>
+      <div class="q-banner__content col text-body2">
+        <h5 class="q-ma-xs">
+          No activities match your filters
+        </h5>
       </div>
-      <div class="row no-padding full-width justify-end bottom-actions q-card__section q-card__section--vert">
-        <!----> <button tabindex="0" type="button" role="button" class="q-btn q-btn-item non-selectable no-outline action-button q-btn--flat q-btn--rectangle text-secondary q-btn--actionable q-focusable q-hoverable q-btn--no-uppercase q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-mr-xs icon-chat material-icons q-icon notranslate" style="font-size:18px;">chat</i> <span class="block">Open Chat</span></span></span></button>
-      </div>
-    </div>
-    <div class="q-card">
-      <div class="no-padding content q-card__section q-card__section--vert isEmpty">
-        <div class="content-inner">
-          <div class="row no-wrap items-start justify-between">
-            <div><strong class="featured-text">
-            12:00 PM
-            <!----></strong>
-              Sunday, December 24, 2017
-            </div> <i aria-hidden="true" role="presentation" title="" class="q-ml-sm q-icon notranslate" style="font-size:18px;top:1px;"></i>
-          </div>
-          <!---->
-          <!---->
-          <!---->
-          <div class="q-mt-sm q-mb-none full-width">
-            <div class="row justify-start"><object tabindex="-1" type="text/html" data="about:blank" aria-hidden="true" style="display:block;position:absolute;top:0;left:0;right:0;bottom:0;height:100%;width:100%;overflow:hidden;pointer-events:none;z-index:-1;"></object>
-              <!---->
-              <div class="user-slot-wrapper active" style="width:36px;height:36px;">
-                <div title="Join" class="show-picture-on-hover">
-                  <div class="wrapper" style="width:36px;height:36px;">
-                    <div text="User 11" seed="11" class="randomArt fill"></div>
-                  </div>
-                </div>
-              </div>
-              <div class="user-slot-wrapper greyedOut" style="width:36px;height:36px;"></div>
-              <div class="user-slot-wrapper greyedOut" style="width:36px;height:36px;"></div>
-              <div class="user-slot-wrapper greyedOut" style="width:36px;height:36px;"></div>
-              <div class="user-slot-wrapper greyedOut" style="width:36px;height:36px;"></div>
-              <div class="user-slot-wrapper greyedOut" style="width:36px;height:36px;"></div>
-              <div class="emptySlots" style="width:36px;height:36px;">
-                <div></div> <span>+ 4</span>
-                <!---->
-                <!---->
-              </div>
-            </div>
-            <!---->
-            <!---->
-          </div>
-        </div>
-      </div>
-      <div class="row no-padding full-width justify-end bottom-actions q-card__section q-card__section--vert">
-        <!----> <button tabindex="0" type="button" role="button" class="q-btn q-btn-item non-selectable no-outline action-button q-btn--flat q-btn--rectangle text-secondary q-btn--actionable q-focusable q-hoverable q-btn--no-uppercase q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-mr-xs icon-chat material-icons q-icon notranslate" style="font-size:18px;">chat</i> <span class="block">Open Chat</span></span></span></button>
-      </div>
-    </div>
-    <div class="q-card">
-      <div class="no-padding content q-card__section q-card__section--vert isEmpty">
-        <div class="content-inner">
-          <div class="row no-wrap items-start justify-between">
-            <div><strong class="featured-text">
-            12:00 PM
-            <!----></strong>
-              Sunday, December 24, 2017
-            </div> <i aria-hidden="true" role="presentation" title="" class="q-ml-sm q-icon notranslate" style="font-size:18px;top:1px;"></i>
-          </div>
-          <!---->
-          <!---->
-          <!---->
-          <div class="q-mt-sm q-mb-none full-width">
-            <div class="row justify-start"><object tabindex="-1" type="text/html" data="about:blank" aria-hidden="true" style="display:block;position:absolute;top:0;left:0;right:0;bottom:0;height:100%;width:100%;overflow:hidden;pointer-events:none;z-index:-1;"></object>
-              <!---->
-              <div class="user-slot-wrapper active" style="width:36px;height:36px;">
-                <div title="Join" class="show-picture-on-hover">
-                  <div class="wrapper" style="width:36px;height:36px;">
-                    <div text="User 11" seed="11" class="randomArt fill"></div>
-                  </div>
-                </div>
-              </div>
-              <div class="user-slot-wrapper greyedOut" style="width:36px;height:36px;"></div>
-              <div class="user-slot-wrapper greyedOut" style="width:36px;height:36px;"></div>
-              <div class="user-slot-wrapper greyedOut" style="width:36px;height:36px;"></div>
-              <div class="user-slot-wrapper greyedOut" style="width:36px;height:36px;"></div>
-              <div class="user-slot-wrapper greyedOut" style="width:36px;height:36px;"></div>
-              <div class="emptySlots" style="width:36px;height:36px;">
-                <div></div> <span>+ 4</span>
-                <!---->
-                <!---->
-              </div>
-            </div>
-            <!---->
-            <!---->
-          </div>
-        </div>
-      </div>
-      <div class="row no-padding full-width justify-end bottom-actions q-card__section q-card__section--vert">
-        <!----> <button tabindex="0" type="button" role="button" class="q-btn q-btn-item non-selectable no-outline action-button q-btn--flat q-btn--rectangle text-secondary q-btn--actionable q-focusable q-hoverable q-btn--no-uppercase q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-mr-xs icon-chat material-icons q-icon notranslate" style="font-size:18px;">chat</i> <span class="block">Open Chat</span></span></span></button>
-      </div>
-    </div>
-    <div class="q-card">
-      <div class="no-padding content q-card__section q-card__section--vert isEmpty">
-        <div class="content-inner">
-          <div class="row no-wrap items-start justify-between">
-            <div><strong class="featured-text">
-            12:00 PM
-            <!----></strong>
-              Sunday, December 24, 2017
-            </div> <i aria-hidden="true" role="presentation" title="" class="q-ml-sm q-icon notranslate" style="font-size:18px;top:1px;"></i>
-          </div>
-          <!---->
-          <!---->
-          <!---->
-          <div class="q-mt-sm q-mb-none full-width">
-            <div class="row justify-start"><object tabindex="-1" type="text/html" data="about:blank" aria-hidden="true" style="display:block;position:absolute;top:0;left:0;right:0;bottom:0;height:100%;width:100%;overflow:hidden;pointer-events:none;z-index:-1;"></object>
-              <!---->
-              <div class="user-slot-wrapper active" style="width:36px;height:36px;">
-                <div title="Join" class="show-picture-on-hover">
-                  <div class="wrapper" style="width:36px;height:36px;">
-                    <div text="User 11" seed="11" class="randomArt fill"></div>
-                  </div>
-                </div>
-              </div>
-              <div class="user-slot-wrapper greyedOut" style="width:36px;height:36px;"></div>
-              <div class="user-slot-wrapper greyedOut" style="width:36px;height:36px;"></div>
-              <div class="user-slot-wrapper greyedOut" style="width:36px;height:36px;"></div>
-              <div class="user-slot-wrapper greyedOut" style="width:36px;height:36px;"></div>
-              <div class="user-slot-wrapper greyedOut" style="width:36px;height:36px;"></div>
-              <div class="emptySlots" style="width:36px;height:36px;">
-                <div></div> <span>+ 4</span>
-                <!---->
-                <!---->
-              </div>
-            </div>
-            <!---->
-            <!---->
-          </div>
-        </div>
-      </div>
-      <div class="row no-padding full-width justify-end bottom-actions q-card__section q-card__section--vert">
-        <!----> <button tabindex="0" type="button" role="button" class="q-btn q-btn-item non-selectable no-outline action-button q-btn--flat q-btn--rectangle text-secondary q-btn--actionable q-focusable q-hoverable q-btn--no-uppercase q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-mr-xs icon-chat material-icons q-icon notranslate" style="font-size:18px;">chat</i> <span class="block">Open Chat</span></span></span></button>
-      </div>
-    </div>
-    <div class="q-card">
-      <div class="no-padding content q-card__section q-card__section--vert isEmpty">
-        <div class="content-inner">
-          <div class="row no-wrap items-start justify-between">
-            <div><strong class="featured-text">
-            12:00 PM
-            <!----></strong>
-              Sunday, December 24, 2017
-            </div> <i aria-hidden="true" role="presentation" title="" class="q-ml-sm q-icon notranslate" style="font-size:18px;top:1px;"></i>
-          </div>
-          <!---->
-          <!---->
-          <!---->
-          <div class="q-mt-sm q-mb-none full-width">
-            <div class="row justify-start"><object tabindex="-1" type="text/html" data="about:blank" aria-hidden="true" style="display:block;position:absolute;top:0;left:0;right:0;bottom:0;height:100%;width:100%;overflow:hidden;pointer-events:none;z-index:-1;"></object>
-              <!---->
-              <div class="user-slot-wrapper active" style="width:36px;height:36px;">
-                <div title="Join" class="show-picture-on-hover">
-                  <div class="wrapper" style="width:36px;height:36px;">
-                    <div text="User 11" seed="11" class="randomArt fill"></div>
-                  </div>
-                </div>
-              </div>
-              <div class="user-slot-wrapper greyedOut" style="width:36px;height:36px;"></div>
-              <div class="user-slot-wrapper greyedOut" style="width:36px;height:36px;"></div>
-              <div class="user-slot-wrapper greyedOut" style="width:36px;height:36px;"></div>
-              <div class="user-slot-wrapper greyedOut" style="width:36px;height:36px;"></div>
-              <div class="user-slot-wrapper greyedOut" style="width:36px;height:36px;"></div>
-              <div class="emptySlots" style="width:36px;height:36px;">
-                <div></div> <span>+ 4</span>
-                <!---->
-                <!---->
-              </div>
-            </div>
-            <!---->
-            <!---->
-          </div>
-        </div>
-      </div>
-      <div class="row no-padding full-width justify-end bottom-actions q-card__section q-card__section--vert">
-        <!----> <button tabindex="0" type="button" role="button" class="q-btn q-btn-item non-selectable no-outline action-button q-btn--flat q-btn--rectangle text-secondary q-btn--actionable q-focusable q-hoverable q-btn--no-uppercase q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-mr-xs icon-chat material-icons q-icon notranslate" style="font-size:18px;">chat</i> <span class="block">Open Chat</span></span></span></button>
-      </div>
+      <div class="q-banner__actions row items-center justify-end col-auto"><button tabindex="0" type="button" role="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--rectangle q-btn--actionable q-focusable q-hoverable q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row">
+          Clear filters
+        </span></span></button></div>
     </div>
   </div>
+  <div class="q-infinite-scroll"></div>
 </div>
 `;
 

--- a/src/activities/components/ActivityList.vue
+++ b/src/activities/components/ActivityList.vue
@@ -44,6 +44,34 @@
         hide-bottom-space
         dense
       />
+      <q-checkbox
+        v-model="mon"
+        label="Mon"
+      />
+      <q-checkbox
+        v-model="tues"
+        label="Tues"
+      />
+      <q-checkbox
+        v-model="wed"
+        label="Wed"
+      />
+      <q-checkbox
+        v-model="thurs"
+        label="Thurs"
+      />
+      <q-checkbox
+        v-model="fri"
+        label="Fri"
+      />
+      <q-checkbox
+        v-model="sat"
+        label="Sat"
+      />
+      <q-checkbox
+        v-model="sun"
+        label="Sun"
+      />
       <div class="text-caption q-ml-xs col text-right">
         {{ filteredActivities.length }} / {{ activities.length }}
       </div>
@@ -374,6 +402,7 @@ export default {
       return this.activities
         .filter(this.slotFilter)
         .filter(this.typeFilter)
+        .filter(this.dayFilter)
     },
     displayedActivitiesGroupedByDate () {
       const result = []
@@ -421,6 +450,16 @@ export default {
     typeFilter (activity) {
       if (this.type === 'all') return true
       return activity.activityType && String(activity.activityType.id) === this.type
+    },
+    dayFilter (activity) {
+      if (this.mon && this.$d(activity.date, 'dayName') === 'Monday') return true
+      if (this.tues && this.$d(activity.date, 'dayName') === 'Tuesday') return true
+      if (this.wed && this.$d(activity.date, 'dayName') === 'Wednesday') return true
+      if (this.thurs && this.$d(activity.date, 'dayName') === 'Thursday') return true
+      if (this.fri && this.$d(activity.date, 'dayName') === 'Friday') return true
+      if (this.sat && this.$d(activity.date, 'dayName') === 'Saturday') return true
+      if (this.sun && this.$d(activity.date, 'dayName') === 'Sunday') return true
+      return false
     },
     clearFilters () {
       this.slots = 'all'


### PR DESCRIPTION
Closes #2310 

## What does this PR do?

Add "day of week" filter for activities on the activities page.

A written test is not needed as we can test out the functionality manually. I first created
activities that cover all the days of a week as a whole group but not individually. Then I tried to apply all possible combinations of the filter to see if only activities of the selected days of the week appear.

## Links to related issues

## Checklist

- [x] added a test, or explain why one is not needed/possible...
- [x] no unrelated changes
- [x] asked someone for a code review
- [x] joined [#karrot:matrix.org](https://matrix.to/#/#karrot:matrix.org)
- [x] added an entry to CHANGELOG.md (description, pull request link, username(s))
- [ ] tried out on a mobile device (does everything work as expected on a smaller screen?)
