### PR TITLE
Add more statistics filter options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Please document your changes in this format:
 ## [Unreleased]
 ### Added
 - Add "Previous 12 months" to statistics time period @changjus [#2445]
+- Add recent years option to statistics time period @nicksellen [#2467]
 
 ## [9.5.1] - 2021-11-08
 ### Changed

--- a/src/locales/locale-en.json
+++ b/src/locales/locale-en.json
@@ -704,6 +704,7 @@
     "FILTER_USER_LABEL": "User",
     "FILTER_ALL_USERS": "All users",
     "FILTER_TIME_LABEL": "Time period",
+    "FILTER_TIME_YEARS_LABEL": "Years",
     "FILTER_TIME_PREVIOUS_DAYS": "Previous {count} days",
     "FILTER_TIME_PREVIOUS_MONTHS": "Previous {count} months",
     "FILTER_TIME_FOREVER": "Forever",

--- a/src/statistics/pages/ActivityHistoryStatistics.vue
+++ b/src/statistics/pages/ActivityHistoryStatistics.vue
@@ -89,7 +89,7 @@
 </template>
 
 <script>
-import { QSelect, QTable, QToggle, QItem, QItemSection, QItemLabel, QSeparator} from 'quasar'
+import { QSelect, QTable, QToggle, QItem, QItemSection, QItemLabel, QSeparator } from 'quasar'
 import subDays from 'date-fns/subDays'
 import subMonths from 'date-fns/subMonths'
 

--- a/src/statistics/pages/ActivityHistoryStatistics.vue
+++ b/src/statistics/pages/ActivityHistoryStatistics.vue
@@ -29,7 +29,28 @@
           filled
           :options="periodFilterOptions"
           class="q-mr-sm"
-        />
+          style="min-width: 180px;"
+        >
+          <template #option="{ index, itemProps, itemEvents, opt: { label: itemLabel, sectionLabel } }">
+            <template v-if="sectionLabel">
+              <QSeparator />
+              <QItemLabel header>
+                {{ sectionLabel }}
+              </QItemLabel>
+            </template>
+            <QItem
+              :key="index"
+              v-bind="itemProps"
+              v-on="itemEvents"
+            >
+              <QItemSection>
+                <QItemLabel>
+                  {{ itemLabel }}
+                </QItemLabel>
+              </QItemSection>
+            </QItem>
+          </template>
+        </QSelect>
         <QSelect
           v-model="leftOptionsSelected"
           :label="$t('STATISTICS.COLUMN_ACTIVITY_LEFT')"
@@ -68,13 +89,14 @@
 </template>
 
 <script>
-import { QSelect, QTable, QToggle, QItem, QItemSection, QItemLabel } from 'quasar'
+import { QSelect, QTable, QToggle, QItem, QItemSection, QItemLabel, QSeparator} from 'quasar'
 import subDays from 'date-fns/subDays'
 import subMonths from 'date-fns/subMonths'
 
 import api from '@/statistics/api/statistics'
 import { mapGetters } from 'vuex'
 import { indexById } from '@/utils/datastore/helpers'
+import { endOfYear, getYear, startOfYear, subYears } from 'date-fns'
 
 export default {
   components: {
@@ -84,6 +106,7 @@ export default {
     QItem,
     QItemSection,
     QItemLabel,
+    QSeparator,
   },
   data () {
     return {
@@ -178,6 +201,7 @@ export default {
       })
     },
     periodFilterOptions () {
+      const now = new Date()
       return [
         {
           label: this.$t('STATISTICS.FILTER_TIME_PREVIOUS_DAYS', { count: 7 }),
@@ -231,6 +255,43 @@ export default {
           onlyAggregate: true,
           dateQuery () {
             return {}
+          },
+        },
+        {
+          label: getYear(now) - 2,
+          value: 'twoyearsago',
+          onlyAggregate: true,
+          sectionLabel: this.$t('STATISTICS.FILTER_TIME_YEARS_LABEL'),
+          dateQuery () {
+            const date = subYears(new Date(), 2)
+            return {
+              dateAfter: startOfYear(date),
+              dateBefore: endOfYear(date),
+            }
+          },
+        },
+        {
+          label: getYear(now) - 1,
+          value: 'lastyear',
+          onlyAggregate: true,
+          dateQuery () {
+            const date = subYears(new Date(), 1)
+            return {
+              dateAfter: startOfYear(date),
+              dateBefore: endOfYear(date),
+            }
+          },
+        },
+        {
+          label: getYear(now),
+          value: 'thisyear',
+          onlyAggregate: true,
+          dateQuery () {
+            const date = new Date()
+            return {
+              dateAfter: startOfYear(date),
+              dateBefore: endOfYear(date),
+            }
           },
         },
       ].map(option => {


### PR DESCRIPTION
## What does this PR do?

Improves the time period options for the activity statistics filter.

- I fixed a bug that meant you could select a single user when you weren't supposed to be able to
- I added "Years" section with the current year and the previous two years, so you can select full calender years

Looks like this:

![yearsfilter](https://user-images.githubusercontent.com/31616/147241931-ae659809-7847-47bc-bdc5-8e99372de56c.png)


## Links to related issues

## Checklist

- [ ] asked someone for a code review
- [x] joined [#karrot:matrix.org](https://matrix.to/#/#karrot:matrix.org)
- [x] added an entry to CHANGELOG.md (description, pull request link, username(s))
- [x] tried out on a mobile device (does everything work as expected on a smaller screen?)
