### PR TITLE
Use config API more

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "bugs": "https://github.com/karrot-dev/karrot-frontend/issues",
   "scripts": {
     "dev": "quasar dev",
+    "dev:pwa": "quasar dev -m pwa",
     "dev:backend:dev": "cross-env BACKEND=https://dev.karrot.world quasar dev",
     "dev:backend:local": "cross-env BACKEND=http://localhost:8000 quasar dev",
     "build": "quasar build -m pwa",

--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -49,7 +49,6 @@ module.exports = configure(function (ctx) {
     KARROT: {
       BACKEND: backend,
       THEME: process.env.KARROT_THEME,
-      FCM_CONFIG: process.env.FCM_CONFIG,
       GIT_SHA1: process.env.GIT_SHA1 || process.env.CIRCLE_SHA1,
     },
     // vuelidate wants this

--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -50,7 +50,6 @@ module.exports = configure(function (ctx) {
       BACKEND: backend,
       THEME: process.env.KARROT_THEME,
       FCM_CONFIG: process.env.FCM_CONFIG,
-      SENTRY_CONFIG: process.env.SENTRY_CONFIG,
       GIT_SHA1: process.env.GIT_SHA1 || process.env.CIRCLE_SHA1,
     },
     // vuelidate wants this
@@ -78,7 +77,6 @@ module.exports = configure(function (ctx) {
       'helloDeveloper',
       'addressbar-color',
       'socket',
-      'sentry',
       'cordova',
       'i18n',
       'loadInitialData',

--- a/src-pwa/firebase.js
+++ b/src-pwa/firebase.js
@@ -1,15 +1,13 @@
-import 'firebase/messaging'
-// eslint-disable-next-line import/default
-import firebase from 'firebase/app'
-import firebaseConfig from '@/subscriptions/firebase.config'
-
-const app = firebase.initializeApp(firebaseConfig)
+import { initializeApp } from 'firebase/app'
+import { getMessaging, onBackgroundMessage } from 'firebase/messaging/sw'
+import { getFirebaseConfig } from '@/subscriptions/firebase.config'
 
 export async function init () {
-  // Actually start showing background notifications
-  const messaging = firebase.messaging(app)
+  const firebaseConfig = await getFirebaseConfig()
+  const app = initializeApp(firebaseConfig)
+  const messaging = getMessaging(app)
 
-  messaging.onBackgroundMessage(payload => {
+  onBackgroundMessage(messaging, payload => {
     // not actually used, but without it here firefox does not receive messages...
     console.log('onBackgroundMessage', payload)
   })

--- a/src/boot/loadInitialData.js
+++ b/src/boot/loadInitialData.js
@@ -1,9 +1,15 @@
 import { isNetworkError } from '@/utils/datastore/helpers'
 import bootstrap from '@/base/api/bootstrap'
+import { configureSentry } from '@/utils/sentry'
 
 export default async function ({ store: datastore }) {
   const bootstrapData = await bootstrap.fetch()
-  const { user, groups, geoip } = bootstrapData
+  const { config, user, groups, geoip } = bootstrapData
+  if (config) {
+    if (config.sentry) {
+      configureSentry(config.sentry)
+    }
+  }
   if (groups) {
     datastore.commit('groups/set', groups)
   }

--- a/src/subscriptions/datastore/auth/push.js
+++ b/src/subscriptions/datastore/auth/push.js
@@ -33,12 +33,12 @@ export default {
 
         commit('setIntention', true)
 
-        const messaging = await initializeMessaging()
+        const { getToken } = await initializeMessaging()
 
         const serviceWorkerRegistration = await getServiceWorkerRegistration()
         let token
         try {
-          token = await messaging.getToken({ serviceWorkerRegistration })
+          token = await getToken({ serviceWorkerRegistration })
         }
         catch (err) {
           if (err.code === 'messaging/notifications-blocked' || err.code === 'messaging/permission-blocked') {
@@ -81,7 +81,7 @@ export default {
       if (state.intention === true) {
         await dispatch('enable')
         const registration = await getServiceWorkerRegistration()
-        registration.update()
+        await registration.update()
       }
       else if (state.intention === false) {
         await dispatch('disable')

--- a/src/subscriptions/firebase.config.js
+++ b/src/subscriptions/firebase.config.js
@@ -1,8 +1,12 @@
-let config = {}
-if (process.env.KARROT.FCM_CONFIG === 'dev') {
-  config = require('./firebase.config.dev').default
+import { camelizeKeys } from '@/utils/utils'
+
+let config
+export async function getFirebaseConfig () {
+  if (config) return config
+  const data = await fetch('/api/config/').then(res => res.json())
+  if (data.fcm) {
+    config = camelizeKeys(data.fcm)
+    return config
+  }
+  return null
 }
-else if (process.env.KARROT.FCM_CONFIG === 'prod') {
-  config = require('./firebase.config.prod').default
-}
-export default config

--- a/src/subscriptions/firebase.lib.js
+++ b/src/subscriptions/firebase.lib.js
@@ -1,6 +1,4 @@
-import 'firebase/messaging'
-// eslint-disable-next-line import/default
-import firebase from 'firebase/app'
+import { getMessaging, onMessage, getToken, deleteToken } from 'firebase/messaging'
+import { initializeApp } from 'firebase/app'
 
-const { initializeApp, messaging } = firebase
-export { initializeApp, messaging }
+export { initializeApp, getMessaging, onMessage, getToken, deleteToken }

--- a/src/utils/sentry.js
+++ b/src/utils/sentry.js
@@ -2,9 +2,13 @@ import Vue from 'vue'
 import * as Sentry from '@sentry/browser'
 import * as Integrations from '@sentry/integrations'
 
-if (process.env.KARROT.SENTRY_CONFIG) {
+export function configureSentry ({ dsn, environment }) {
+  if (process.env.DEV) {
+    environment = 'dev'
+  }
   Sentry.init({
-    dsn: process.env.KARROT.SENTRY_CONFIG,
+    dsn,
+    environment,
     integrations: [
       new Integrations.Vue({ Vue, logErrors: true }),
       new Integrations.ExtraErrorData(),


### PR DESCRIPTION
Branch deployment: https://change-use-more-config-api.dev.karrot.world

## What does this PR do?

The backend sends client config via `/api/config/` and `/api/bootstrap/` (e.g. https://dev.karrot.world/api/config/) end points, but so far the client hasn't actually made use of it yet.

This changes it to use the config API for sentry and FCM purposes.

It also fixes some firebase related errors I introduced recently.

(The point of having the config API is so that we don't have to bake this kind of config into the frontend at build time, it'll just use whatever the backend sends it, which is configured via environment variables on the server).

## Links to related issues

## Checklist

- [ ] added a test, or explain why one is not needed/possible...
- [ ] no unrelated changes
- [ ] asked someone for a code review
- [ ] joined [#karrot:matrix.org](https://matrix.to/#/#karrot:matrix.org)
- [ ] added an entry to CHANGELOG.md (description, pull request link, username(s))
- [ ] tried out on a mobile device (does everything work as expected on a smaller screen?)
