### PR TITLE
Fix places navigation

### DIFF
--- a/src-cordova/playstoreAssets/en-US/listing/shortDescription.txt
+++ b/src-cordova/playstoreAssets/en-US/listing/shortDescription.txt
@@ -1,1 +1,1 @@
-Karrot is a free and open-source tool for grassroots initiatives and groups of people that want to coordinate face-to-face activities on a local, autonomous and voluntary basis.
+Karrot is a free and open-source tool for grassroots initiatives

--- a/src/base/datastore/routerPlugin.js
+++ b/src/base/datastore/routerPlugin.js
@@ -77,6 +77,15 @@ export default datastore => {
       Sentry.captureException(err)
     }
 
+    // Would have preferred to do this in a beforeEnter action but it wasn't possible...
+    // ... the limiting factor was when you click back on the place list in the sidebar it
+    // doesn't trigger the beforeEnter action (because of our design), and so gets stuck
+    if (to.name === 'place') {
+      const place = datastore.getters['places/get'](to.params.placeId)
+      const name = place.defaultView === 'wall' ? 'placeWall' : 'placeActivities'
+      await router.push({ name, params: to.params })
+    }
+
     // Check if our route requires any features we don't have
     // It would be nice to do this _before_ we visit the route, but we don't have the features
     // available at that point

--- a/src/base/routes/main.js
+++ b/src/base/routes/main.js
@@ -460,7 +460,7 @@ export default [
           breadcrumbs: [
             { type: 'activePlace' },
           ],
-          beforeEnter: 'places/routeEnter',
+          beforeEnter: 'places/selectPlace',
           afterLeave: 'places/clearSelectedPlace',
         },
         components: {

--- a/src/places/components/PlaceTabs.vue
+++ b/src/places/components/PlaceTabs.vue
@@ -8,7 +8,6 @@
       v-for="(tab, idx) in tabs"
       :key="idx"
       :to="tab.to"
-      :default="idx === 0"
       :label="tab.label"
       exact
     >

--- a/src/places/datastore/places.js
+++ b/src/places/datastore/places.js
@@ -9,7 +9,6 @@ import {
   indexById,
   createRouteError,
   toggles,
-  createRouteRedirect,
 } from '@/utils/datastore/helpers'
 import router from '@/router'
 
@@ -74,13 +73,6 @@ export default {
     },
   },
   actions: {
-    async routeEnter ({ dispatch, getters }, { groupId, placeId, routeTo }) {
-      if (placeId) {
-        await dispatch('selectPlace', { placeId })
-        const place = getters.get(placeId)
-        throw createRouteRedirect({ name: placeRoute(place), params: { groupId, placeId }, query: routeTo.query })
-      }
-    },
     ...withMeta({
       async save ({ dispatch }, place) {
         dispatch('update', [await places.save(place)])


### PR DESCRIPTION
Closes #2469 

## What does this PR do?

There were two problems:
- navigating directly to a place subpage would send you to it's default view (fix: only trigger the redirect logic when directly visiting the place base page, not subpages)
- clicking on the place in the menu when you were on a place subpage would make it show nothing, as it got stuck on the place base page, this is because the route actions do not get retriggered when navigating to a higher up page (fix: move the logic into the main router plugin... not elegant, but otherwise would require some fiddly rethinking/coding of some of the router logic)

## Links to related issues

## Checklist

- [ ] added a test, or explain why one is not needed/possible...
- [ ] no unrelated changes
- [ ] asked someone for a code review
- [ ] joined [#karrot:matrix.org](https://matrix.to/#/#karrot:matrix.org)
- [ ] added an entry to CHANGELOG.md (description, pull request link, username(s))
- [ ] tried out on a mobile device (does everything work as expected on a smaller screen?)
