### PR TITLE
Fix markdown link attributes

### DIFF
--- a/src/utils/components/markdownRenderer.js
+++ b/src/utils/components/markdownRenderer.js
@@ -3,21 +3,19 @@ import markdownLinkAttributes from 'markdown-it-link-attributes'
 import emoji from 'markdown-it-emoji'
 import defaultEmojiShortcuts from 'markdown-it-emoji/lib/data/shortcuts'
 import twemoji from 'twemoji'
-import escapeRegExp from 'escape-string-regexp'
 
 // Use a more basic smile for the default normal simple smile
 const emojiShortcuts = { ...defaultEmojiShortcuts }
 emojiShortcuts.slightly_smiling_face = emojiShortcuts.smiley
 delete emojiShortcuts.smiley
 
-const internalLinkParts = ['$']
+const internalBaseURLs = []
 if (!window.location.href.startsWith('file:///')) {
-  internalLinkParts.push(escapeRegExp(window.location.href.split('/#')[0]))
+  internalBaseURLs.push(window.location.href.split('/#')[0])
 }
 if (process.env.KARROT.BACKEND) {
-  internalLinkParts.push(escapeRegExp(process.env.KARROT.BACKEND))
+  internalBaseURLs.push(process.env.KARROT.BACKEND)
 }
-const internalLinkPattern = RegExp(`^(${internalLinkParts.join('|')})`)
 
 const md = markdownIt('zero', {
   html: false,
@@ -28,24 +26,23 @@ const md = markdownIt('zero', {
 })
   .use(markdownLinkAttributes, [
     {
-      pattern: /^mailto:/,
+      matcher: href => href.startsWith('mailto:'),
       attrs: {
         class: 'fas-after fa-after-envelope',
       },
     },
     {
-      pattern: /^tel:/,
+      matcher: href => href.startsWith('tel:'),
       attrs: {
         class: 'fas-after fa-after-phone',
       },
     },
     {
-      pattern: internalLinkPattern,
+      matcher: href => internalBaseURLs.find(baseURL => href.startsWith(baseURL)),
       attrs: {},
     },
     {
       // default to external link
-      pattern: /.*/,
       attrs: {
         target: '_blank',
         rel: 'noopener nofollow noreferrer',


### PR DESCRIPTION
Fixes #2481

## What does this PR do?

Library change meant that it was necessary to switch to `matcher` configuration instead of `pattern` (see https://github.com/crookedneighbor/markdown-it-link-attributes/blob/main/CHANGELOG.md#400).

## Links to related issues

## Checklist

- [ ] added a test, or explain why one is not needed/possible...
- [ ] no unrelated changes
- [ ] asked someone for a code review
- [ ] joined [#karrot:matrix.org](https://matrix.to/#/#karrot:matrix.org)
- [ ] added an entry to CHANGELOG.md (description, pull request link, username(s))
- [ ] tried out on a mobile device (does everything work as expected on a smaller screen?)
