### PR TITLE
Scroll to wall messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Please document your changes in this format:
 ## [Unreleased]
 ### Added
 - enabled Japanese, and Chinese (simplified), and a few library locales @nicksellen [#2475]
+- scroll to wall messages when clicking message in menu @nicksellen [#2483]
 
 ## [9.6.1] - 2021-12-29
 ### Changed

--- a/src/messages/components/LatestConversations.vue
+++ b/src/messages/components/LatestConversations.vue
@@ -110,7 +110,7 @@ export default {
     open (conv) {
       const { type, target } = conv
       switch (type) {
-        case 'group': return this.$router.push({ name: 'group', params: { groupId: target.id } }).catch(() => {})
+        case 'group': return this.$router.push({ name: 'group', params: { groupId: target.id }, hash: '#messages' }).catch(() => {})
         case 'place': return this.$router.push({ name: 'placeWall', params: { groupId: target.group.id, placeId: target.id } }).catch(() => {})
         case 'activity': return this.openForActivity(target)
         case 'private': return this.openForUser(target)

--- a/src/messages/components/WallConversation.vue
+++ b/src/messages/components/WallConversation.vue
@@ -5,6 +5,7 @@
       @load="maybeFetchPast"
     >
       <QList
+        ref="messagesList"
         class="bg-white desktop-margin relative-position q-pb-md"
         bordered
       >
@@ -121,6 +122,17 @@ export default {
       }
       else {
         return this.$t('WALL.WRITE_FIRST_MESSAGE')
+      }
+    },
+  },
+  watch: {
+    hasLoaded (val) {
+      if (val) {
+        const hash = this.$route.hash
+        if (hash === '#messages') {
+          const ref = this.$refs.messagesList
+          if (ref) ref.$el.scrollIntoView()
+        }
       }
     },
   },


### PR DESCRIPTION
Closes #2318 

## What does this PR do?

- supports routing to `/#/group/<id>/wall#messages`
- this is used in the messages menu in the top bar
- once the messages are loaded it will jump to the top of the messages

Limitations:
- can't jump to individual messages
- if you're already on the wall, it won't jump, only from another page
- the top part (the message input box) might end up underneath the topbar in some cases
- I had to implement it in the wall component, as that's the only place that knows the messages are loaded

## Links to related issues

## Checklist

- [ ] added a test, or explain why one is not needed/possible...
- [ ] no unrelated changes
- [ ] asked someone for a code review
- [ ] joined [#karrot:matrix.org](https://matrix.to/#/#karrot:matrix.org)
- [ ] added an entry to CHANGELOG.md (description, pull request link, username(s))
- [ ] tried out on a mobile device (does everything work as expected on a smaller screen?)
