### PR TITLE
Round translation figures up to nearest integer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Please document your changes in this format:
 ## [Unreleased]
 ### Fixed
 - fix infinite redirect for some discussions @amengsk [#2501](https://github.com/karrot-dev/karrot-frontend/pull/2501)
+- fix round translation percentages @Chinchuluun1029 @nicksellen [#2514](https://github.com/karrot-dev/karrot-frontend/pull/2514)
 
 ## [9.7.0] - 2022-02-15
 ### Added

--- a/src/utils/components/LocaleSelectInner.vue
+++ b/src/utils/components/LocaleSelectInner.vue
@@ -47,7 +47,7 @@
       <QItemSection>
         <QItemLabel>
           {{ locale.label }}
-          <small>({{ (locale.percentage * 100).toFixed() }}%)</small>
+          <small>({{ Math.round(locale.percentage * 100) }}%)</small>
         </QItemLabel>
         <QItemLabel caption>
           <QLinearProgress

--- a/src/utils/components/LocaleSelectInner.vue
+++ b/src/utils/components/LocaleSelectInner.vue
@@ -47,7 +47,7 @@
       <QItemSection>
         <QItemLabel>
           {{ locale.label }}
-          <small>({{ locale.percentage * 100 }}%)</small>
+          <small>({{ (locale.percentage * 100).toFixed() }}%)</small>
         </QItemLabel>
         <QItemLabel caption>
           <QLinearProgress


### PR DESCRIPTION
Closes #2499

## What does this PR do?

Fixes the high precision issue on the translated coverages. 

Before:
![154041902-efdd4bf5-0990-46ef-b8d9-0bef06d78f30](https://user-images.githubusercontent.com/31333688/158001158-957c873e-9981-45ca-bd1b-9ade36af2793.png)
After: 
<img width="216" alt="Screen Shot 2022-03-11 at 20 59 19" src="https://user-images.githubusercontent.com/31333688/158001190-80f4a9c8-150f-4e2f-ae27-62e3fa9e8188.png">


## Links to related issues

## Checklist

- [ ] added a test, or explain why one is not needed/possible...
- [x] no unrelated changes
- [x] asked someone for a code review
- [x] joined [#karrot:matrix.org](https://matrix.to/#/#karrot:matrix.org)
- [x] added an entry to CHANGELOG.md (description, pull request link, username(s))
- [x] tried out on a mobile device (does everything work as expected on a smaller screen?)
