### PR TITLE
Archived type filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Please document your changes in this format:
 ```
 
 ## [Unreleased]
+### Fixed
+- show archived types in filter if activities of that type exist @nitishvijai @yatharthchhabra [#2506](https://github.com/karrot-dev/karrot-frontend/issues/2506)
 
 ## [9.8.1] - 2022-03-25
 ### Fixed

--- a/src/activities/components/ActivityList.vue
+++ b/src/activities/components/ActivityList.vue
@@ -436,23 +436,20 @@ export default {
       for (const activityType in this.activityListTypeFilter) {
         // count the number of archived types and store in a hashmap, defaulting to zero
         if (this.activityListTypeFilter[activityType].status === 'archived') {
-          archivedTypes[this.activityListTypeFilter[activityType].id] = 0
+          archivedTypes[this.activityListTypeFilter[activityType].id] = false
         }
       }
 
-      console.log(this.activities)
-
-      for (const num in this.activities) {
-        // count the number of activities for each archived type and update the hashmap
-        const activity = this.activities[num]
+      for (const activity of this.activities) {
+        // check to see if each archived type has any activities and update the hashmap
         if (activity.activityType.id in archivedTypes) {
           const id = activity.activityType.id
-          archivedTypes[id] += 1
+          archivedTypes[id] = true
         }
       }
 
       for (const archivedTypeId in archivedTypes) {
-        if (archivedTypes[archivedTypeId] === 0) {
+        if (archivedTypes[archivedTypeId] === false) {
           // For any archived types with zero activities in view, remove the type from the filter
           for (const [index, activityType] of this.activityListTypeFilter.entries()) {
             if (parseInt(activityType.id) === parseInt(archivedTypeId)) {

--- a/src/activities/components/ActivityList.vue
+++ b/src/activities/components/ActivityList.vue
@@ -334,28 +334,20 @@ export default {
       icsDialog: false,
       numDisplayed: NUM_ACTIVITIES_PER_LOAD,
       types: [],
-      activityListTypeFilter: this.filterActivityTypes.slice(),
     }
   },
   computed: {
     activityTypes () {
-      const archivedTypeList = []
+      const activityTypes = this.filterActivityTypes.slice()
       const archivedTypes = {}
 
-      for (const type of this.activityListTypeFilter) {
-        // populate a list of all activity types locally to avoid side effects
-        archivedTypeList.push(type)
-      }
-
-      for (const activityType of archivedTypeList) {
-        // count the number of archived types and store in a hashmap, defaulting to zero
+      for (const activityType of activityTypes) {
         if (activityType.status === 'archived') {
           archivedTypes[activityType.id] = false
         }
       }
 
       for (const activity of this.activities) {
-        // check to see if each archived type has any activities and update the hashmap
         if (activity.activityType.id in archivedTypes) {
           const id = activity.activityType.id
           archivedTypes[id] = true
@@ -363,20 +355,19 @@ export default {
       }
 
       for (const archivedTypeId in archivedTypes) {
-        console.log(archivedTypeId)
         if (archivedTypes[archivedTypeId] === false) {
           // For any archived types with zero activities in view, remove the type from the filter
-          for (const [index, activityType] of archivedTypeList.entries()) {
+          for (const [index, activityType] of activityTypes.entries()) {
             if (parseInt(activityType.id) === parseInt(archivedTypeId)) {
               // delete archived type from the filter
-              archivedTypeList.splice(index, 1)
+              activityTypes.splice(index, 1)
               break
             }
           }
         }
       }
 
-      return archivedTypeList
+      return activityTypes
     },
     slotsOptions () {
       return [

--- a/src/maps/components/StandardMap.vue
+++ b/src/maps/components/StandardMap.vue
@@ -40,7 +40,7 @@
     >
       <slot
         name="contextmenu"
-        :latLng="popoverLatLng"
+        :lat-lng="popoverLatLng"
       />
     </QMenu>
   </LMap>


### PR DESCRIPTION
Closes #2506

## What does this PR do?

This pull request should fix the issue where archived types should be shown in the filter if there are activities of that type in view, otherwise should not be in the filter.

Tested manually in the following cases: an archived activity type whose activities are in view, an archived activity type when no activities of that type exist, and when activities of an archived type are being deleted. However, looking to add a unit test once we get more direction on how to proceed from Nick. `yarn lint` and `yarn test` pass locally on our changes.

![image](https://user-images.githubusercontent.com/51350879/164334991-d31c4a4d-880f-480c-8785-7b9e980d68ee.png)

<img width="1585" alt="image" src="https://user-images.githubusercontent.com/51350879/164335268-0145ef22-22da-4b27-a324-c6937bf187cd.png">

## Links to related issues

## Checklist

- [ ] added a test, or explain why one is not needed/possible...
- [x] no unrelated changes
- [x] asked someone for a code review
- [x] joined [#karrot:matrix.org](https://matrix.to/#/#karrot:matrix.org)
- [x] added an entry to CHANGELOG.md (description, pull request link, username(s))
- [x] tried out on a mobile device (does everything work as expected on a smaller screen?)
