### PR TITLE
Added the UI component and validation for username change in profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Please document your changes in this format:
 ### Fixed
 - show archived types in filter if activities of that type exist @nitishvijai @yatharthchhabra [#2506](https://github.com/karrot-dev/karrot-frontend/issues/2506)
 
+### Added
+- added the UI component and validation for username change in profile @Chinchuluun1029 @nicksellen [#2523](https://github.com/karrot-dev/karrot-frontend/issues/2523)
+
 ## [9.8.1] - 2022-03-25
 ### Fixed
 - fix username pattern matching @nicksellen [#2520]

--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -7,8 +7,8 @@ exports[`Storyshots ActivitiesManage default 1`] = `
       <div class="text-h6"><i class="fas fa-redo on-left"></i>
         Activity series
       </div>
-      <div class="q-fab z-fab row inline justify-center fab-top-fix q-fab--align-right q-fab--form-rounded"><a tabindex="0" role="button" aria-expanded="false" aria-haspopup="true" class="q-btn q-btn-item non-selectable no-outline q-btn--standard q-btn--rectangle q-btn--rounded bg-secondary text-white q-btn--actionable q-focusable q-hoverable q-btn--fab q-btn--no-uppercase q-fab--form-rounded"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row no-wrap text-no-wrap"><div class="q-fab__icon-holder"><i aria-hidden="true" role="presentation" class="q-fab__icon absolute-full q-icon fas fa-plus"> </i><i aria-hidden="true" role="presentation" class="q-fab__active-icon absolute-full q-icon notranslate material-icons">close</i></div></span></span></a>
-        <div class="q-fab__actions flex no-wrap inline q-fab__actions--down"><a tabindex="-1" aria-disabled="true" class="q-btn q-btn-item non-selectable no-outline fab-action-fix q-btn--standard q-btn--rectangle q-btn--rounded disabled q-btn--fab-mini q-btn--no-uppercase q-fab--form-rounded"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row no-wrap text-no-wrap"><div class="q-fab__label q-fab__label--internal q-fab__label--internal-left">Pickup</div><i aria-hidden="true" role="presentation" class="q-icon fas fa-shopping-basket"> </i></span></span></a> <a tabindex="-1" aria-disabled="true" class="q-btn q-btn-item non-selectable no-outline fab-action-fix bg-white q-btn--outline q-btn--rectangle q-btn--rounded disabled q-btn--fab-mini q-btn--no-uppercase q-fab--form-rounded"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row no-wrap text-no-wrap"><div class="q-fab__label q-fab__label--internal q-fab__label--internal-right">Manage types...</div></span></span></a></div>
+      <div class="q-fab z-fab row inline justify-center fab-top-fix q-fab--align-right q-fab--form-rounded"><a tabindex="0" role="button" aria-expanded="false" aria-haspopup="true" class="q-btn q-btn-item non-selectable no-outline q-btn--standard q-btn--rectangle q-btn--rounded bg-secondary text-white q-btn--actionable q-focusable q-hoverable q-btn--fab q-btn--no-uppercase q-fab--form-rounded"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row no-wrap text-no-wrap"><div class="q-fab__icon-holder"><i aria-hidden="true" role="presentation" class="q-fab__icon absolute-full fas fa-plus q-icon"> </i><i aria-hidden="true" role="presentation" class="q-fab__active-icon absolute-full notranslate material-icons q-icon">close</i></div></span></span></a>
+        <div class="q-fab__actions flex no-wrap inline q-fab__actions--down"><a tabindex="-1" aria-disabled="true" class="q-btn q-btn-item non-selectable no-outline fab-action-fix q-btn--standard q-btn--rectangle q-btn--rounded disabled q-btn--fab-mini q-btn--no-uppercase q-fab--form-rounded"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row no-wrap text-no-wrap"><div class="q-fab__label q-fab__label--internal q-fab__label--internal-left">Pickup</div><i aria-hidden="true" role="presentation" class="fas fa-shopping-basket q-icon"> </i></span></span></a> <a tabindex="-1" aria-disabled="true" class="q-btn q-btn-item non-selectable no-outline fab-action-fix bg-white q-btn--outline q-btn--rectangle q-btn--rounded disabled q-btn--fab-mini q-btn--no-uppercase q-fab--form-rounded"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row no-wrap text-no-wrap"><div class="q-fab__label q-fab__label--internal q-fab__label--internal-right">Manage types...</div></span></span></a></div>
       </div>
     </div>
     <!---->
@@ -40,7 +40,7 @@ exports[`Storyshots ActivitiesManage default 1`] = `
                 12:00 PM
               </div>
             </div>
-            <div class="q-item__section column q-focusable relative-position cursor-pointer q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-expansion-item__toggle-icon q-icon notranslate material-icons">keyboard_arrow_down</i></div>
+            <div class="q-item__section column q-focusable relative-position cursor-pointer q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-expansion-item__toggle-icon notranslate material-icons q-icon">keyboard_arrow_down</i></div>
           </div>
           <transition-stub>
             <div class="q-expansion-item__content relative-position" style="display:none;">
@@ -60,8 +60,8 @@ exports[`Storyshots ActivitiesManage default 1`] = `
       <div class="text-h6"><i class="on-left fas fa-asterisk"></i>
         One-time activities
       </div>
-      <div class="q-fab z-fab row inline justify-center q-fab--align-right q-fab--form-rounded"><a tabindex="0" role="button" aria-expanded="false" aria-haspopup="true" class="q-btn q-btn-item non-selectable no-outline q-btn--standard q-btn--rectangle q-btn--rounded bg-secondary text-white q-btn--actionable q-focusable q-hoverable q-btn--fab q-btn--no-uppercase q-fab--form-rounded"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row no-wrap text-no-wrap"><div class="q-fab__icon-holder"><i aria-hidden="true" role="presentation" class="q-fab__icon absolute-full q-icon fas fa-plus"> </i><i aria-hidden="true" role="presentation" class="q-fab__active-icon absolute-full q-icon notranslate material-icons">close</i></div></span></span></a>
-        <div class="q-fab__actions flex no-wrap inline q-fab__actions--down"><a tabindex="-1" aria-disabled="true" class="q-btn q-btn-item non-selectable no-outline fab-action-fix q-btn--standard q-btn--rectangle q-btn--rounded disabled q-btn--fab-mini q-btn--no-uppercase q-fab--form-rounded"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row no-wrap text-no-wrap"><div class="q-fab__label q-fab__label--internal q-fab__label--internal-left">Pickup</div><i aria-hidden="true" role="presentation" class="q-icon fas fa-shopping-basket"> </i></span></span></a> <a tabindex="-1" aria-disabled="true" class="q-btn q-btn-item non-selectable no-outline fab-action-fix bg-white q-btn--outline q-btn--rectangle q-btn--rounded disabled q-btn--fab-mini q-btn--no-uppercase q-fab--form-rounded"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row no-wrap text-no-wrap"><div class="q-fab__label q-fab__label--internal q-fab__label--internal-right">Manage types...</div></span></span></a></div>
+      <div class="q-fab z-fab row inline justify-center q-fab--align-right q-fab--form-rounded"><a tabindex="0" role="button" aria-expanded="false" aria-haspopup="true" class="q-btn q-btn-item non-selectable no-outline q-btn--standard q-btn--rectangle q-btn--rounded bg-secondary text-white q-btn--actionable q-focusable q-hoverable q-btn--fab q-btn--no-uppercase q-fab--form-rounded"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row no-wrap text-no-wrap"><div class="q-fab__icon-holder"><i aria-hidden="true" role="presentation" class="q-fab__icon absolute-full fas fa-plus q-icon"> </i><i aria-hidden="true" role="presentation" class="q-fab__active-icon absolute-full notranslate material-icons q-icon">close</i></div></span></span></a>
+        <div class="q-fab__actions flex no-wrap inline q-fab__actions--down"><a tabindex="-1" aria-disabled="true" class="q-btn q-btn-item non-selectable no-outline fab-action-fix q-btn--standard q-btn--rectangle q-btn--rounded disabled q-btn--fab-mini q-btn--no-uppercase q-fab--form-rounded"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row no-wrap text-no-wrap"><div class="q-fab__label q-fab__label--internal q-fab__label--internal-left">Pickup</div><i aria-hidden="true" role="presentation" class="fas fa-shopping-basket q-icon"> </i></span></span></a> <a tabindex="-1" aria-disabled="true" class="q-btn q-btn-item non-selectable no-outline fab-action-fix bg-white q-btn--outline q-btn--rectangle q-btn--rounded disabled q-btn--fab-mini q-btn--no-uppercase q-fab--form-rounded"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row no-wrap text-no-wrap"><div class="q-fab__label q-fab__label--internal q-fab__label--internal-right">Manage types...</div></span></span></a></div>
       </div>
     </div>
     <!---->
@@ -94,7 +94,7 @@ exports[`Storyshots ActivitiesManage default 1`] = `
                 <!---->
               </div>
             </div>
-            <div class="q-item__section column q-focusable relative-position cursor-pointer q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-expansion-item__toggle-icon q-icon notranslate material-icons">keyboard_arrow_down</i></div>
+            <div class="q-item__section column q-focusable relative-position cursor-pointer q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-expansion-item__toggle-icon notranslate material-icons q-icon">keyboard_arrow_down</i></div>
           </div>
           <transition-stub>
             <div class="q-expansion-item__content relative-position" style="display:none;"></div>
@@ -115,7 +115,7 @@ exports[`Storyshots ActivitiesManage default 1`] = `
                 <!---->
               </div>
             </div>
-            <div class="q-item__section column q-focusable relative-position cursor-pointer q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-expansion-item__toggle-icon q-icon notranslate material-icons">keyboard_arrow_down</i></div>
+            <div class="q-item__section column q-focusable relative-position cursor-pointer q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-expansion-item__toggle-icon notranslate material-icons q-icon">keyboard_arrow_down</i></div>
           </div>
           <transition-stub>
             <div class="q-expansion-item__content relative-position" style="display:none;"></div>
@@ -136,7 +136,7 @@ exports[`Storyshots ActivitiesManage default 1`] = `
                 <!---->
               </div>
             </div>
-            <div class="q-item__section column q-focusable relative-position cursor-pointer q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-expansion-item__toggle-icon q-icon notranslate material-icons">keyboard_arrow_down</i></div>
+            <div class="q-item__section column q-focusable relative-position cursor-pointer q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-expansion-item__toggle-icon notranslate material-icons q-icon">keyboard_arrow_down</i></div>
           </div>
           <transition-stub>
             <div class="q-expansion-item__content relative-position" style="display:none;"></div>
@@ -157,7 +157,7 @@ exports[`Storyshots ActivitiesManage default 1`] = `
                 <!---->
               </div>
             </div>
-            <div class="q-item__section column q-focusable relative-position cursor-pointer q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-expansion-item__toggle-icon q-icon notranslate material-icons">keyboard_arrow_down</i></div>
+            <div class="q-item__section column q-focusable relative-position cursor-pointer q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-expansion-item__toggle-icon notranslate material-icons q-icon">keyboard_arrow_down</i></div>
           </div>
           <transition-stub>
             <div class="q-expansion-item__content relative-position" style="display:none;"></div>
@@ -178,7 +178,7 @@ exports[`Storyshots ActivitiesManage default 1`] = `
                 <!---->
               </div>
             </div>
-            <div class="q-item__section column q-focusable relative-position cursor-pointer q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-expansion-item__toggle-icon q-icon notranslate material-icons">keyboard_arrow_down</i></div>
+            <div class="q-item__section column q-focusable relative-position cursor-pointer q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-expansion-item__toggle-icon notranslate material-icons q-icon">keyboard_arrow_down</i></div>
           </div>
           <transition-stub>
             <div class="q-expansion-item__content relative-position" style="display:none;"></div>
@@ -198,7 +198,7 @@ exports[`Storyshots ActivityEdit default 1`] = `
   <form class="q-gutter-y-lg" style="max-width:700px;">
     <!---->
     <div class="row q-mt-xs"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-mr-sm q-input q-field--standard q-field--float">
-        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">access_time</i></div>
+        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">access_time</i></div>
         <div class="q-field__inner relative-position col self-stretch">
           <div tabindex="-1" class="q-field__control relative-position row no-wrap">
             <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" size="9" id="f_80808080-8080-4080-8080-808080808080" type="text" value="2017-12-24" class="q-field__native q-placeholder">
@@ -214,7 +214,7 @@ exports[`Storyshots ActivityEdit default 1`] = `
             </div>
           </div>
         </div>
-        <div class="q-field__after q-field__marginal row no-wrap items-center"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-ml-xs q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap" style="font-size:8px;"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon fas fa-plus"> </i></span></span></button></div>
+        <div class="q-field__after q-field__marginal row no-wrap items-center"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-ml-xs q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap" style="font-size:8px;"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="fas fa-plus q-icon"> </i></span></span></button></div>
       </label>
       <!---->
       <div class="q-ml-lg col-12 q-field__bottom">
@@ -224,7 +224,7 @@ exports[`Storyshots ActivityEdit default 1`] = `
       </div>
     </div>
     <div><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--standard q-field--float q-field--labeled q-field--with-bottom">
-        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">group</i></div>
+        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">group</i></div>
         <div class="q-field__inner relative-position col self-stretch">
           <div tabindex="-1" class="q-field__control relative-position row no-wrap">
             <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" aria-label="Max Slots" placeholder="unlimited" id="f_80808080-8080-4080-8080-808080808080" type="number" value="10" class="q-field__native q-placeholder" style="max-width:100px;">
@@ -265,7 +265,7 @@ exports[`Storyshots ActivityEdit default 1`] = `
     <div>
       <div class="mentionable" style="position:relative;">
         <div class="relative-position q-mb-sm"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-textarea q-textarea--autogrow q-field--standard q-field--labeled q-field--with-bottom">
-            <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">info</i></div>
+            <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">info</i></div>
             <div class="q-field__inner relative-position col self-stretch">
               <div tabindex="-1" class="q-field__control relative-position row no-wrap">
                 <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><textarea tabindex="0" rows="1" aria-label="Additional information" id="f_80808080-8080-4080-8080-808080808080" type="textarea" maxlength="500" class="q-field__native q-placeholder" style="min-height:100px;"></textarea>
@@ -328,7 +328,7 @@ exports[`Storyshots ActivityEdit disabled 1`] = `
   <form class="q-gutter-y-lg" style="max-width:700px;">
     <!---->
     <div class="row q-mt-xs"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-mr-sm q-input q-field--standard q-field--float">
-        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">access_time</i></div>
+        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">access_time</i></div>
         <div class="q-field__inner relative-position col self-stretch">
           <div tabindex="-1" class="q-field__control relative-position row no-wrap">
             <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" size="9" id="f_80808080-8080-4080-8080-808080808080" type="text" value="2017-12-24" class="q-field__native q-placeholder">
@@ -344,7 +344,7 @@ exports[`Storyshots ActivityEdit disabled 1`] = `
             </div>
           </div>
         </div>
-        <div class="q-field__after q-field__marginal row no-wrap items-center"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-ml-xs q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap" style="font-size:8px;"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon fas fa-plus"> </i></span></span></button></div>
+        <div class="q-field__after q-field__marginal row no-wrap items-center"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-ml-xs q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap" style="font-size:8px;"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="fas fa-plus q-icon"> </i></span></span></button></div>
       </label>
       <!---->
       <div class="q-ml-lg col-12 q-field__bottom">
@@ -354,7 +354,7 @@ exports[`Storyshots ActivityEdit disabled 1`] = `
       </div>
     </div>
     <div><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--standard q-field--float q-field--labeled q-field--with-bottom">
-        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">group</i></div>
+        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">group</i></div>
         <div class="q-field__inner relative-position col self-stretch">
           <div tabindex="-1" class="q-field__control relative-position row no-wrap">
             <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" aria-label="Max Slots" placeholder="unlimited" id="f_80808080-8080-4080-8080-808080808080" type="number" value="10" class="q-field__native q-placeholder" style="max-width:100px;">
@@ -395,7 +395,7 @@ exports[`Storyshots ActivityEdit disabled 1`] = `
     <div>
       <div class="mentionable" style="position:relative;">
         <div class="relative-position q-mb-sm"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-textarea q-textarea--autogrow q-field--standard q-field--labeled q-field--with-bottom">
-            <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">info</i></div>
+            <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">info</i></div>
             <div class="q-field__inner relative-position col self-stretch">
               <div tabindex="-1" class="q-field__control relative-position row no-wrap">
                 <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><textarea tabindex="0" rows="1" aria-label="Additional information" id="f_80808080-8080-4080-8080-808080808080" type="textarea" maxlength="500" class="q-field__native q-placeholder" style="min-height:100px;"></textarea>
@@ -458,13 +458,13 @@ exports[`Storyshots ActivityEdit error 1`] = `
   <form class="q-gutter-y-lg" style="max-width:700px;">
     <!---->
     <div class="row q-mt-xs"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-mr-sm q-input q-field--standard q-field--highlighted q-field--float q-field--error">
-        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">access_time</i></div>
+        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">access_time</i></div>
         <div class="q-field__inner relative-position col self-stretch">
           <div tabindex="-1" class="q-field__control relative-position row no-wrap text-negative">
             <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" size="9" id="f_80808080-8080-4080-8080-808080808080" type="text" value="2017-12-24" class="q-field__native q-placeholder">
               <!---->
             </div>
-            <div class="q-field__append q-field__marginal row no-wrap items-center q-anchor--skip"><i aria-hidden="true" role="presentation" class="q-icon text-negative notranslate material-icons">error</i></div>
+            <div class="q-field__append q-field__marginal row no-wrap items-center q-anchor--skip"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon text-negative">error</i></div>
           </div>
         </div>
       </label> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--standard q-field--highlighted q-field--float q-field--error">
@@ -473,10 +473,10 @@ exports[`Storyshots ActivityEdit error 1`] = `
             <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" size="3" id="f_80808080-8080-4080-8080-808080808080" type="text" value="12:00" class="q-field__native q-placeholder">
               <!---->
             </div>
-            <div class="q-field__append q-field__marginal row no-wrap items-center q-anchor--skip"><i aria-hidden="true" role="presentation" class="q-icon text-negative notranslate material-icons">error</i></div>
+            <div class="q-field__append q-field__marginal row no-wrap items-center q-anchor--skip"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon text-negative">error</i></div>
           </div>
         </div>
-        <div class="q-field__after q-field__marginal row no-wrap items-center"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-ml-xs q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap" style="font-size:8px;"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon fas fa-plus"> </i></span></span></button></div>
+        <div class="q-field__after q-field__marginal row no-wrap items-center"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-ml-xs q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap" style="font-size:8px;"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="fas fa-plus q-icon"> </i></span></span></button></div>
       </label>
       <!---->
       <div class="q-ml-lg col-12 q-field__bottom">
@@ -486,7 +486,7 @@ exports[`Storyshots ActivityEdit error 1`] = `
       </div>
     </div>
     <div><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--standard q-field--float q-field--labeled q-field--with-bottom">
-        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">group</i></div>
+        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">group</i></div>
         <div class="q-field__inner relative-position col self-stretch">
           <div tabindex="-1" class="q-field__control relative-position row no-wrap">
             <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" aria-label="Max Slots" placeholder="unlimited" id="f_80808080-8080-4080-8080-808080808080" type="number" value="10" class="q-field__native q-placeholder" style="max-width:100px;">
@@ -527,7 +527,7 @@ exports[`Storyshots ActivityEdit error 1`] = `
     <div>
       <div class="mentionable" style="position:relative;">
         <div class="relative-position q-mb-sm"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-textarea q-textarea--autogrow q-field--standard q-field--labeled q-field--with-bottom">
-            <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">info</i></div>
+            <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">info</i></div>
             <div class="q-field__inner relative-position col self-stretch">
               <div tabindex="-1" class="q-field__control relative-position row no-wrap">
                 <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><textarea tabindex="0" rows="1" aria-label="Additional information" id="f_80808080-8080-4080-8080-808080808080" type="textarea" maxlength="500" class="q-field__native q-placeholder" style="min-height:100px;"></textarea>
@@ -590,7 +590,7 @@ exports[`Storyshots ActivityEdit pending 1`] = `
   <form class="q-gutter-y-lg" style="max-width:700px;">
     <!---->
     <div class="row q-mt-xs"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-mr-sm q-input q-field--standard q-field--float">
-        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">access_time</i></div>
+        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">access_time</i></div>
         <div class="q-field__inner relative-position col self-stretch">
           <div tabindex="-1" class="q-field__control relative-position row no-wrap">
             <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" size="9" id="f_80808080-8080-4080-8080-808080808080" type="text" value="2017-12-24" class="q-field__native q-placeholder">
@@ -606,7 +606,7 @@ exports[`Storyshots ActivityEdit pending 1`] = `
             </div>
           </div>
         </div>
-        <div class="q-field__after q-field__marginal row no-wrap items-center"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-ml-xs q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap" style="font-size:8px;"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon fas fa-plus"> </i></span></span></button></div>
+        <div class="q-field__after q-field__marginal row no-wrap items-center"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-ml-xs q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap" style="font-size:8px;"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="fas fa-plus q-icon"> </i></span></span></button></div>
       </label>
       <!---->
       <div class="q-ml-lg col-12 q-field__bottom">
@@ -616,7 +616,7 @@ exports[`Storyshots ActivityEdit pending 1`] = `
       </div>
     </div>
     <div><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--standard q-field--float q-field--labeled q-field--with-bottom">
-        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">group</i></div>
+        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">group</i></div>
         <div class="q-field__inner relative-position col self-stretch">
           <div tabindex="-1" class="q-field__control relative-position row no-wrap">
             <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" aria-label="Max Slots" placeholder="unlimited" id="f_80808080-8080-4080-8080-808080808080" type="number" value="10" class="q-field__native q-placeholder" style="max-width:100px;">
@@ -657,7 +657,7 @@ exports[`Storyshots ActivityEdit pending 1`] = `
     <div>
       <div class="mentionable" style="position:relative;">
         <div class="relative-position q-mb-sm"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-textarea q-textarea--autogrow q-field--standard q-field--labeled q-field--with-bottom">
-            <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">info</i></div>
+            <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">info</i></div>
             <div class="q-field__inner relative-position col self-stretch">
               <div tabindex="-1" class="q-field__control relative-position row no-wrap">
                 <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><textarea tabindex="0" rows="1" aria-label="Additional information" id="f_80808080-8080-4080-8080-808080808080" type="textarea" maxlength="500" class="q-field__native q-placeholder" style="min-height:100px;"></textarea>
@@ -720,7 +720,7 @@ exports[`Storyshots ActivityEdit series changed 1`] = `
   <form class="q-gutter-y-lg" style="max-width:700px;">
     <!---->
     <div class="row q-mt-xs"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-mr-sm q-input q-field--standard q-field--float">
-        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">access_time</i></div>
+        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">access_time</i></div>
         <div class="q-field__inner relative-position col self-stretch">
           <div tabindex="-1" class="q-field__control relative-position row no-wrap">
             <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" size="9" id="f_80808080-8080-4080-8080-808080808080" type="text" value="2017-12-24" class="q-field__native q-placeholder">
@@ -736,7 +736,7 @@ exports[`Storyshots ActivityEdit series changed 1`] = `
             </div>
           </div>
         </div>
-        <div class="q-field__after q-field__marginal row no-wrap items-center"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-ml-xs q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap" style="font-size:8px;"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon fas fa-plus"> </i></span></span></button></div>
+        <div class="q-field__after q-field__marginal row no-wrap items-center"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-ml-xs q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap" style="font-size:8px;"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="fas fa-plus q-icon"> </i></span></span></button></div>
       </label>
       <!---->
       <div class="q-ml-lg col-12 q-field__bottom">
@@ -746,7 +746,7 @@ exports[`Storyshots ActivityEdit series changed 1`] = `
       </div>
     </div>
     <div><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--standard q-field--float q-field--labeled q-field--with-bottom">
-        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">group</i></div>
+        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">group</i></div>
         <div class="q-field__inner relative-position col self-stretch">
           <div tabindex="-1" class="q-field__control relative-position row no-wrap">
             <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" aria-label="Max Slots" placeholder="unlimited" id="f_80808080-8080-4080-8080-808080808080" type="number" value="10" class="q-field__native q-placeholder" style="max-width:100px;">
@@ -780,16 +780,16 @@ exports[`Storyshots ActivityEdit series changed 1`] = `
             </transition-stub>
           </div>
         </div>
-        <div class="q-field__after q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">undo</i></div>
+        <div class="q-field__after q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">undo</i></div>
       </label>
-      <div class="q-ml-lg col-12 q-field__bottom text-warning"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">warning</i>
+      <div class="q-ml-lg col-12 q-field__bottom text-warning"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">warning</i>
         This value differs from the default. To undo this change, click on the arrow button and save the changes.
       </div>
     </div>
     <div>
       <div class="mentionable" style="position:relative;">
         <div class="relative-position q-mb-sm"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-textarea q-textarea--autogrow q-field--standard q-field--labeled q-field--with-bottom">
-            <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">info</i></div>
+            <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">info</i></div>
             <div class="q-field__inner relative-position col self-stretch">
               <div tabindex="-1" class="q-field__control relative-position row no-wrap">
                 <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><textarea tabindex="0" rows="1" aria-label="Additional information" id="f_80808080-8080-4080-8080-808080808080" type="textarea" maxlength="500" class="q-field__native q-placeholder" style="min-height:100px;"></textarea>
@@ -802,7 +802,7 @@ exports[`Storyshots ActivityEdit series changed 1`] = `
                 </transition-stub>
               </div>
             </div>
-            <div class="q-field__after q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">undo</i></div>
+            <div class="q-field__after q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">undo</i></div>
           </label>
           <!---->
         </div>
@@ -825,7 +825,7 @@ exports[`Storyshots ActivityEdit series changed 1`] = `
           </div>
         </div>
       </div>
-      <div class="q-ml-lg col-12 q-field__bottom text-warning"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">warning</i>
+      <div class="q-ml-lg col-12 q-field__bottom text-warning"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">warning</i>
         This value differs from the default. To undo this change, click on the arrow button and save the changes.
       </div>
     </div>
@@ -854,7 +854,7 @@ exports[`Storyshots ActivityEdit with duration 1`] = `
   <form class="q-gutter-y-lg" style="max-width:700px;">
     <!---->
     <div class="row q-mt-xs"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-mr-sm q-input q-field--standard q-field--float">
-        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">access_time</i></div>
+        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">access_time</i></div>
         <div class="q-field__inner relative-position col self-stretch">
           <div tabindex="-1" class="q-field__control relative-position row no-wrap">
             <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" size="9" id="f_80808080-8080-4080-8080-808080808080" type="text" value="2017-12-24" class="q-field__native q-placeholder">
@@ -880,7 +880,7 @@ exports[`Storyshots ActivityEdit with duration 1`] = `
             </div>
           </div>
         </div>
-        <div class="q-field__after q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="cursor-pointer q-icon text-grey notranslate material-icons">cancel</i>
+        <div class="q-field__after q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="cursor-pointer notranslate material-icons q-icon text-grey">cancel</i>
           <div class="text-caption q-ml-xs">
             (30 minutes)
           </div>
@@ -893,7 +893,7 @@ exports[`Storyshots ActivityEdit with duration 1`] = `
       </div>
     </div>
     <div><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--standard q-field--float q-field--labeled q-field--with-bottom">
-        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">group</i></div>
+        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">group</i></div>
         <div class="q-field__inner relative-position col self-stretch">
           <div tabindex="-1" class="q-field__control relative-position row no-wrap">
             <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" aria-label="Max Slots" placeholder="unlimited" id="f_80808080-8080-4080-8080-808080808080" type="number" value="10" class="q-field__native q-placeholder" style="max-width:100px;">
@@ -934,7 +934,7 @@ exports[`Storyshots ActivityEdit with duration 1`] = `
     <div>
       <div class="mentionable" style="position:relative;">
         <div class="relative-position q-mb-sm"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-textarea q-textarea--autogrow q-field--standard q-field--labeled q-field--with-bottom">
-            <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">info</i></div>
+            <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">info</i></div>
             <div class="q-field__inner relative-position col self-stretch">
               <div tabindex="-1" class="q-field__control relative-position row no-wrap">
                 <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><textarea tabindex="0" rows="1" aria-label="Additional information" id="f_80808080-8080-4080-8080-808080808080" type="textarea" maxlength="500" class="q-field__native q-placeholder" style="min-height:100px;"></textarea>
@@ -1041,7 +1041,7 @@ exports[`Storyshots ActivityItem disabled 1`] = `
     </div>
   </div>
   <div class="row no-padding full-width justify-end bottom-actions q-card__section q-card__section--vert">
-    <!----> <button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline action-button q-btn--flat q-btn--rectangle text-secondary q-btn--actionable q-focusable q-hoverable q-btn--no-uppercase q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-mr-xs icon-chat q-icon notranslate material-icons" style="font-size:18px;">chat</i> <span class="block">Open Chat</span></span></span></button>
+    <!----> <button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline action-button q-btn--flat q-btn--rectangle text-secondary q-btn--actionable q-focusable q-hoverable q-btn--no-uppercase q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-mr-xs icon-chat notranslate material-icons q-icon" style="font-size:18px;">chat</i> <span class="block">Open Chat</span></span></span></button>
   </div>
 </div>
 `;
@@ -1098,7 +1098,7 @@ exports[`Storyshots ActivityItem full 1`] = `
     </div>
   </div>
   <div class="row no-padding full-width justify-end bottom-actions q-card__section q-card__section--vert">
-    <!----> <button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline action-button q-btn--flat q-btn--rectangle text-secondary q-btn--actionable q-focusable q-hoverable q-btn--no-uppercase q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-mr-xs icon-chat q-icon notranslate material-icons" style="font-size:18px;">chat</i> <span class="block">Open Chat</span></span></span></button>
+    <!----> <button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline action-button q-btn--flat q-btn--rectangle text-secondary q-btn--actionable q-focusable q-hoverable q-btn--no-uppercase q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-mr-xs icon-chat notranslate material-icons q-icon" style="font-size:18px;">chat</i> <span class="block">Open Chat</span></span></span></button>
   </div>
 </div>
 `;
@@ -1155,7 +1155,7 @@ exports[`Storyshots ActivityItem join 1`] = `
     </div>
   </div>
   <div class="row no-padding full-width justify-end bottom-actions q-card__section q-card__section--vert">
-    <!----> <button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline action-button q-btn--flat q-btn--rectangle text-secondary q-btn--actionable q-focusable q-hoverable q-btn--no-uppercase q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-mr-xs icon-chat q-icon notranslate material-icons" style="font-size:18px;">chat</i> <span class="block">Open Chat</span></span></span></button>
+    <!----> <button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline action-button q-btn--flat q-btn--rectangle text-secondary q-btn--actionable q-focusable q-hoverable q-btn--no-uppercase q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-mr-xs icon-chat notranslate material-icons q-icon" style="font-size:18px;">chat</i> <span class="block">Open Chat</span></span></span></button>
   </div>
 </div>
 `;
@@ -1210,7 +1210,7 @@ exports[`Storyshots ActivityItem joined 1`] = `
       </div>
     </div>
   </div>
-  <div class="row no-padding full-width justify-end bottom-actions q-card__section q-card__section--vert"><a tabindex="0" href="undefined/api/activities/3/ics/" class="q-btn q-btn-item non-selectable no-outline action-button q-btn--flat q-btn--rectangle text-secondary q-btn--actionable q-focusable q-hoverable q-btn--no-uppercase q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-mr-xs q-icon notranslate material-icons" style="font-size:18px;">event</i> <span>Download ICS</span></span></span></a> <button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline action-button q-btn--flat q-btn--rectangle text-secondary q-btn--actionable q-focusable q-hoverable q-btn--no-uppercase q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-mr-xs icon-chat q-icon notranslate material-icons" style="font-size:18px;">chat</i> <span class="block">Open Chat</span></span></span></button></div>
+  <div class="row no-padding full-width justify-end bottom-actions q-card__section q-card__section--vert"><a tabindex="0" href="undefined/api/activities/3/ics/" class="q-btn q-btn-item non-selectable no-outline action-button q-btn--flat q-btn--rectangle text-secondary q-btn--actionable q-focusable q-hoverable q-btn--no-uppercase q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-mr-xs notranslate material-icons q-icon" style="font-size:18px;">event</i> <span>Download ICS</span></span></span></a> <button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline action-button q-btn--flat q-btn--rectangle text-secondary q-btn--actionable q-focusable q-hoverable q-btn--no-uppercase q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-mr-xs icon-chat notranslate material-icons q-icon" style="font-size:18px;">chat</i> <span class="block">Open Chat</span></span></span></button></div>
 </div>
 `;
 
@@ -1262,7 +1262,7 @@ exports[`Storyshots ActivityItem pending 1`] = `
     </div>
   </div>
   <div class="row no-padding full-width justify-end bottom-actions q-card__section q-card__section--vert">
-    <!----> <button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline action-button q-btn--flat q-btn--rectangle text-secondary q-btn--actionable q-focusable q-hoverable q-btn--no-uppercase q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-mr-xs icon-chat q-icon notranslate material-icons" style="font-size:18px;">chat</i> <span class="block">Open Chat</span></span></span></button>
+    <!----> <button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline action-button q-btn--flat q-btn--rectangle text-secondary q-btn--actionable q-focusable q-hoverable q-btn--no-uppercase q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-mr-xs icon-chat notranslate material-icons q-icon" style="font-size:18px;">chat</i> <span class="block">Open Chat</span></span></span></button>
   </div>
 </div>
 `;
@@ -1319,7 +1319,7 @@ exports[`Storyshots ActivityItem started 1`] = `
     </div>
   </div>
   <div class="row no-padding full-width justify-end bottom-actions q-card__section q-card__section--vert">
-    <!----> <button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline action-button q-btn--flat q-btn--rectangle text-secondary q-btn--actionable q-focusable q-hoverable q-btn--no-uppercase q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-mr-xs icon-chat q-icon notranslate material-icons" style="font-size:18px;">chat</i> <span class="block">Open Chat</span></span></span></button>
+    <!----> <button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline action-button q-btn--flat q-btn--rectangle text-secondary q-btn--actionable q-focusable q-hoverable q-btn--no-uppercase q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-mr-xs icon-chat notranslate material-icons q-icon" style="font-size:18px;">chat</i> <span class="block">Open Chat</span></span></span></button>
   </div>
 </div>
 `;
@@ -1390,7 +1390,7 @@ exports[`Storyshots ActivityList Default 1`] = `
         </div>
       </div>
       <div class="row no-padding full-width justify-end bottom-actions q-card__section q-card__section--vert">
-        <!----> <button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline action-button q-btn--flat q-btn--rectangle text-secondary q-btn--actionable q-focusable q-hoverable q-btn--no-uppercase q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-mr-xs icon-chat q-icon notranslate material-icons" style="font-size:18px;">chat</i> <span class="block">Open Chat</span></span></span></button>
+        <!----> <button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline action-button q-btn--flat q-btn--rectangle text-secondary q-btn--actionable q-focusable q-hoverable q-btn--no-uppercase q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-mr-xs icon-chat notranslate material-icons q-icon" style="font-size:18px;">chat</i> <span class="block">Open Chat</span></span></span></button>
       </div>
     </div>
     <div class="q-card">
@@ -1433,7 +1433,7 @@ exports[`Storyshots ActivityList Default 1`] = `
         </div>
       </div>
       <div class="row no-padding full-width justify-end bottom-actions q-card__section q-card__section--vert">
-        <!----> <button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline action-button q-btn--flat q-btn--rectangle text-secondary q-btn--actionable q-focusable q-hoverable q-btn--no-uppercase q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-mr-xs icon-chat q-icon notranslate material-icons" style="font-size:18px;">chat</i> <span class="block">Open Chat</span></span></span></button>
+        <!----> <button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline action-button q-btn--flat q-btn--rectangle text-secondary q-btn--actionable q-focusable q-hoverable q-btn--no-uppercase q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-mr-xs icon-chat notranslate material-icons q-icon" style="font-size:18px;">chat</i> <span class="block">Open Chat</span></span></span></button>
       </div>
     </div>
     <div class="q-card">
@@ -1476,7 +1476,7 @@ exports[`Storyshots ActivityList Default 1`] = `
         </div>
       </div>
       <div class="row no-padding full-width justify-end bottom-actions q-card__section q-card__section--vert">
-        <!----> <button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline action-button q-btn--flat q-btn--rectangle text-secondary q-btn--actionable q-focusable q-hoverable q-btn--no-uppercase q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-mr-xs icon-chat q-icon notranslate material-icons" style="font-size:18px;">chat</i> <span class="block">Open Chat</span></span></span></button>
+        <!----> <button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline action-button q-btn--flat q-btn--rectangle text-secondary q-btn--actionable q-focusable q-hoverable q-btn--no-uppercase q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-mr-xs icon-chat notranslate material-icons q-icon" style="font-size:18px;">chat</i> <span class="block">Open Chat</span></span></span></button>
       </div>
     </div>
     <div class="q-card">
@@ -1519,7 +1519,7 @@ exports[`Storyshots ActivityList Default 1`] = `
         </div>
       </div>
       <div class="row no-padding full-width justify-end bottom-actions q-card__section q-card__section--vert">
-        <!----> <button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline action-button q-btn--flat q-btn--rectangle text-secondary q-btn--actionable q-focusable q-hoverable q-btn--no-uppercase q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-mr-xs icon-chat q-icon notranslate material-icons" style="font-size:18px;">chat</i> <span class="block">Open Chat</span></span></span></button>
+        <!----> <button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline action-button q-btn--flat q-btn--rectangle text-secondary q-btn--actionable q-focusable q-hoverable q-btn--no-uppercase q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-mr-xs icon-chat notranslate material-icons q-icon" style="font-size:18px;">chat</i> <span class="block">Open Chat</span></span></span></button>
       </div>
     </div>
     <div class="q-card">
@@ -1562,7 +1562,7 @@ exports[`Storyshots ActivityList Default 1`] = `
         </div>
       </div>
       <div class="row no-padding full-width justify-end bottom-actions q-card__section q-card__section--vert">
-        <!----> <button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline action-button q-btn--flat q-btn--rectangle text-secondary q-btn--actionable q-focusable q-hoverable q-btn--no-uppercase q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-mr-xs icon-chat q-icon notranslate material-icons" style="font-size:18px;">chat</i> <span class="block">Open Chat</span></span></span></button>
+        <!----> <button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline action-button q-btn--flat q-btn--rectangle text-secondary q-btn--actionable q-focusable q-hoverable q-btn--no-uppercase q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-mr-xs icon-chat notranslate material-icons q-icon" style="font-size:18px;">chat</i> <span class="block">Open Chat</span></span></span></button>
       </div>
     </div>
   </div>
@@ -1573,7 +1573,7 @@ exports[`Storyshots ActivitySeriesEdit custom rule 1`] = `
 <div class="edit-box">
   <form class="q-gutter-y-lg" style="max-width:700px;">
     <!----> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-field--borderless q-field--float q-field--labeled q-field--auto-height">
-      <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-redo"> </i></div>
+      <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-redo q-icon"> </i></div>
       <div class="q-field__inner relative-position col self-stretch">
         <div tabindex="-1" class="q-field__control relative-position row no-wrap">
           <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip">
@@ -1605,7 +1605,7 @@ exports[`Storyshots ActivitySeriesEdit custom rule 1`] = `
       </div>
     </label>
     <div class="row q-mt-xs"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-mr-sm q-input q-field--standard q-field--float">
-        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">access_time</i></div>
+        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">access_time</i></div>
         <div class="q-field__inner relative-position col self-stretch">
           <div tabindex="-1" class="q-field__control relative-position row no-wrap">
             <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" size="9" id="f_80808080-8080-4080-8080-808080808080" type="text" value="2017-12-24" class="q-field__native q-placeholder">
@@ -1621,7 +1621,7 @@ exports[`Storyshots ActivitySeriesEdit custom rule 1`] = `
             </div>
           </div>
         </div>
-        <div class="q-field__after q-field__marginal row no-wrap items-center"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-ml-xs q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap" style="font-size:8px;"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon fas fa-plus"> </i></span></span></button></div>
+        <div class="q-field__after q-field__marginal row no-wrap items-center"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-ml-xs q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap" style="font-size:8px;"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="fas fa-plus q-icon"> </i></span></span></button></div>
       </label>
       <!---->
       <div class="q-ml-lg col-12 q-field__bottom">
@@ -1631,7 +1631,7 @@ exports[`Storyshots ActivitySeriesEdit custom rule 1`] = `
       </div>
     </div>
     <!----> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-textarea q-textarea--autogrow q-field--standard q-field--float q-field--labeled q-field--with-bottom">
-      <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">code</i></div>
+      <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">code</i></div>
       <div class="q-field__inner relative-position col self-stretch">
         <div tabindex="-1" class="q-field__control relative-position row no-wrap">
           <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><textarea tabindex="0" rows="1" aria-label="Recurrence rule" id="f_80808080-8080-4080-8080-808080808080" type="textarea" class="q-field__native q-placeholder">FREQ=WEEKLY;BYDAY=TU</textarea>
@@ -1645,7 +1645,7 @@ exports[`Storyshots ActivitySeriesEdit custom rule 1`] = `
         </div>
       </div>
     </label> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--standard q-field--float q-field--labeled q-field--with-bottom">
-      <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">group</i></div>
+      <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">group</i></div>
       <div class="q-field__inner relative-position col self-stretch">
         <div tabindex="-1" class="q-field__control relative-position row no-wrap">
           <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" aria-label="Max Slots" placeholder="unlimited" id="f_80808080-8080-4080-8080-808080808080" type="number" value="10" class="q-field__native q-placeholder" style="max-width:100px;">
@@ -1682,7 +1682,7 @@ exports[`Storyshots ActivitySeriesEdit custom rule 1`] = `
     </label>
     <div class="mentionable" style="position:relative;">
       <div class="relative-position q-mb-sm"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-textarea q-textarea--autogrow q-field--standard q-field--labeled q-field--with-bottom">
-          <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">info</i></div>
+          <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">info</i></div>
           <div class="q-field__inner relative-position col self-stretch">
             <div tabindex="-1" class="q-field__control relative-position row no-wrap">
               <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><textarea tabindex="0" rows="1" aria-label="Additional information" id="f_80808080-8080-4080-8080-808080808080" type="textarea" maxlength="500" class="q-field__native q-placeholder" style="min-height:100px;"></textarea>
@@ -1737,7 +1737,7 @@ exports[`Storyshots ActivitySeriesEdit custom rule with duration 1`] = `
 <div class="edit-box">
   <form class="q-gutter-y-lg" style="max-width:700px;">
     <!----> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-field--borderless q-field--float q-field--labeled q-field--auto-height">
-      <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-redo"> </i></div>
+      <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-redo q-icon"> </i></div>
       <div class="q-field__inner relative-position col self-stretch">
         <div tabindex="-1" class="q-field__control relative-position row no-wrap">
           <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip">
@@ -1769,7 +1769,7 @@ exports[`Storyshots ActivitySeriesEdit custom rule with duration 1`] = `
       </div>
     </label>
     <div class="row q-mt-xs"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-mr-sm q-input q-field--standard q-field--float">
-        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">access_time</i></div>
+        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">access_time</i></div>
         <div class="q-field__inner relative-position col self-stretch">
           <div tabindex="-1" class="q-field__control relative-position row no-wrap">
             <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" size="9" id="f_80808080-8080-4080-8080-808080808080" type="text" value="2017-12-24" class="q-field__native q-placeholder">
@@ -1795,7 +1795,7 @@ exports[`Storyshots ActivitySeriesEdit custom rule with duration 1`] = `
             </div>
           </div>
         </div>
-        <div class="q-field__after q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="cursor-pointer q-icon text-grey notranslate material-icons">cancel</i>
+        <div class="q-field__after q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="cursor-pointer notranslate material-icons q-icon text-grey">cancel</i>
           <div class="text-caption q-ml-xs">
             (45 minutes)
           </div>
@@ -1808,7 +1808,7 @@ exports[`Storyshots ActivitySeriesEdit custom rule with duration 1`] = `
       </div>
     </div>
     <!----> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-textarea q-textarea--autogrow q-field--standard q-field--float q-field--labeled q-field--with-bottom">
-      <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">code</i></div>
+      <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">code</i></div>
       <div class="q-field__inner relative-position col self-stretch">
         <div tabindex="-1" class="q-field__control relative-position row no-wrap">
           <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><textarea tabindex="0" rows="1" aria-label="Recurrence rule" id="f_80808080-8080-4080-8080-808080808080" type="textarea" class="q-field__native q-placeholder">FREQ=WEEKLY;BYDAY=TU</textarea>
@@ -1822,7 +1822,7 @@ exports[`Storyshots ActivitySeriesEdit custom rule with duration 1`] = `
         </div>
       </div>
     </label> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--standard q-field--float q-field--labeled q-field--with-bottom">
-      <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">group</i></div>
+      <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">group</i></div>
       <div class="q-field__inner relative-position col self-stretch">
         <div tabindex="-1" class="q-field__control relative-position row no-wrap">
           <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" aria-label="Max Slots" placeholder="unlimited" id="f_80808080-8080-4080-8080-808080808080" type="number" value="10" class="q-field__native q-placeholder" style="max-width:100px;">
@@ -1859,7 +1859,7 @@ exports[`Storyshots ActivitySeriesEdit custom rule with duration 1`] = `
     </label>
     <div class="mentionable" style="position:relative;">
       <div class="relative-position q-mb-sm"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-textarea q-textarea--autogrow q-field--standard q-field--labeled q-field--with-bottom">
-          <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">info</i></div>
+          <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">info</i></div>
           <div class="q-field__inner relative-position col self-stretch">
             <div tabindex="-1" class="q-field__control relative-position row no-wrap">
               <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><textarea tabindex="0" rows="1" aria-label="Additional information" id="f_80808080-8080-4080-8080-808080808080" type="textarea" maxlength="500" class="q-field__native q-placeholder" style="min-height:100px;"></textarea>
@@ -1914,7 +1914,7 @@ exports[`Storyshots ActivitySeriesEdit duration 1`] = `
 <div class="edit-box">
   <form class="q-gutter-y-lg" style="max-width:700px;">
     <!----> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-field--borderless q-field--float q-field--labeled q-field--auto-height">
-      <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-redo"> </i></div>
+      <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-redo q-icon"> </i></div>
       <div class="q-field__inner relative-position col self-stretch">
         <div tabindex="-1" class="q-field__control relative-position row no-wrap">
           <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip">
@@ -1947,7 +1947,7 @@ exports[`Storyshots ActivitySeriesEdit duration 1`] = `
     </label>
     <div class="row q-mt-xs">
       <!----> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--standard q-field--float">
-        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">access_time</i></div>
+        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">access_time</i></div>
         <div class="q-field__inner relative-position col self-stretch">
           <div tabindex="-1" class="q-field__control relative-position row no-wrap">
             <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" size="3" id="f_80808080-8080-4080-8080-808080808080" type="text" value="12:00" class="q-field__native q-placeholder">
@@ -1965,7 +1965,7 @@ exports[`Storyshots ActivitySeriesEdit duration 1`] = `
             </div>
           </div>
         </div>
-        <div class="q-field__after q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="cursor-pointer q-icon text-grey notranslate material-icons">cancel</i>
+        <div class="q-field__after q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="cursor-pointer notranslate material-icons q-icon text-grey">cancel</i>
           <div class="text-caption q-ml-xs">
             (45 minutes)
           </div>
@@ -1977,16 +1977,16 @@ exports[`Storyshots ActivitySeriesEdit duration 1`] = `
         </div>
       </div>
     </div> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-select q-field--auto-height q-select--without-input q-select--without-chips q-select--multiple q-field--standard q-field--float q-field--labeled q-field--with-bottom">
-      <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">today</i></div>
+      <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">today</i></div>
       <div class="q-field__inner relative-position col self-stretch">
         <div tabindex="-1" class="q-field__control relative-position row no-wrap">
           <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip">
             <div class="q-field__native row items-center"><span>Tuesday</span>
-              <div id="f_80808080-8080-4080-8080-808080808080" tabindex="0" role="combobox" aria-multiselectable="true" aria-expanded="false" aria-owns="f_80808080-8080-4080-8080-808080808080_lb" aria-activedescendant="f_80808080-8080-4080-8080-808080808080_-1" class="q-select__focus-target"></div>
+              <div id="f_80808080-8080-4080-8080-808080808080" tabindex="0" role="combobox" aria-multiselectable="true" aria-expanded="false" aria-owns="f_80808080-8080-4080-8080-808080808080_lb" aria-activedescendant="f_80808080-8080-4080-8080-808080808080_-1" class="no-outline"></div>
             </div>
             <div class="q-field__label no-pointer-events absolute ellipsis">Weekdays</div>
           </div>
-          <div class="q-field__append q-field__marginal row no-wrap items-center q-anchor--skip"><i aria-hidden="true" role="presentation" class="q-select__dropdown-icon q-icon notranslate material-icons">arrow_drop_down</i></div>
+          <div class="q-field__append q-field__marginal row no-wrap items-center q-anchor--skip"><i aria-hidden="true" role="presentation" class="q-select__dropdown-icon notranslate material-icons q-icon">arrow_drop_down</i></div>
           <!---->
         </div>
         <div class="q-field__bottom row items-start q-field__bottom--animated">
@@ -1999,7 +1999,7 @@ exports[`Storyshots ActivitySeriesEdit duration 1`] = `
       </div>
     </label>
     <!----> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--standard q-field--float q-field--labeled q-field--with-bottom">
-      <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">group</i></div>
+      <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">group</i></div>
       <div class="q-field__inner relative-position col self-stretch">
         <div tabindex="-1" class="q-field__control relative-position row no-wrap">
           <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" aria-label="Max Slots" placeholder="unlimited" id="f_80808080-8080-4080-8080-808080808080" type="number" value="10" class="q-field__native q-placeholder" style="max-width:100px;">
@@ -2036,7 +2036,7 @@ exports[`Storyshots ActivitySeriesEdit duration 1`] = `
     </label>
     <div class="mentionable" style="position:relative;">
       <div class="relative-position q-mb-sm"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-textarea q-textarea--autogrow q-field--standard q-field--labeled q-field--with-bottom">
-          <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">info</i></div>
+          <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">info</i></div>
           <div class="q-field__inner relative-position col self-stretch">
             <div tabindex="-1" class="q-field__control relative-position row no-wrap">
               <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><textarea tabindex="0" rows="1" aria-label="Additional information" id="f_80808080-8080-4080-8080-808080808080" type="textarea" maxlength="500" class="q-field__native q-placeholder" style="min-height:100px;"></textarea>
@@ -2091,7 +2091,7 @@ exports[`Storyshots ActivitySeriesEdit time error 1`] = `
 <div class="edit-box">
   <form class="q-gutter-y-lg" style="max-width:700px;">
     <!----> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-field--borderless q-field--float q-field--labeled q-field--auto-height">
-      <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-redo"> </i></div>
+      <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-redo q-icon"> </i></div>
       <div class="q-field__inner relative-position col self-stretch">
         <div tabindex="-1" class="q-field__control relative-position row no-wrap">
           <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip">
@@ -2124,16 +2124,16 @@ exports[`Storyshots ActivitySeriesEdit time error 1`] = `
     </label>
     <div class="row q-mt-xs">
       <!----> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--standard q-field--highlighted q-field--float q-field--error">
-        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">access_time</i></div>
+        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">access_time</i></div>
         <div class="q-field__inner relative-position col self-stretch">
           <div tabindex="-1" class="q-field__control relative-position row no-wrap text-negative">
             <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" size="3" id="f_80808080-8080-4080-8080-808080808080" type="text" value="12:00" class="q-field__native q-placeholder">
               <!---->
             </div>
-            <div class="q-field__append q-field__marginal row no-wrap items-center q-anchor--skip"><i aria-hidden="true" role="presentation" class="q-icon text-negative notranslate material-icons">error</i></div>
+            <div class="q-field__append q-field__marginal row no-wrap items-center q-anchor--skip"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon text-negative">error</i></div>
           </div>
         </div>
-        <div class="q-field__after q-field__marginal row no-wrap items-center"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-ml-xs q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap" style="font-size:8px;"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon fas fa-plus"> </i></span></span></button></div>
+        <div class="q-field__after q-field__marginal row no-wrap items-center"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-ml-xs q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap" style="font-size:8px;"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="fas fa-plus q-icon"> </i></span></span></button></div>
       </label>
       <!---->
       <div class="q-ml-lg col-12 q-field__bottom">
@@ -2142,16 +2142,16 @@ exports[`Storyshots ActivitySeriesEdit time error 1`] = `
         </div>
       </div>
     </div> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-select q-field--auto-height q-select--without-input q-select--without-chips q-select--multiple q-field--standard q-field--float q-field--labeled q-field--with-bottom">
-      <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">today</i></div>
+      <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">today</i></div>
       <div class="q-field__inner relative-position col self-stretch">
         <div tabindex="-1" class="q-field__control relative-position row no-wrap">
           <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip">
             <div class="q-field__native row items-center"><span>Tuesday</span>
-              <div id="f_80808080-8080-4080-8080-808080808080" tabindex="0" role="combobox" aria-multiselectable="true" aria-expanded="false" aria-owns="f_80808080-8080-4080-8080-808080808080_lb" aria-activedescendant="f_80808080-8080-4080-8080-808080808080_-1" class="q-select__focus-target"></div>
+              <div id="f_80808080-8080-4080-8080-808080808080" tabindex="0" role="combobox" aria-multiselectable="true" aria-expanded="false" aria-owns="f_80808080-8080-4080-8080-808080808080_lb" aria-activedescendant="f_80808080-8080-4080-8080-808080808080_-1" class="no-outline"></div>
             </div>
             <div class="q-field__label no-pointer-events absolute ellipsis">Weekdays</div>
           </div>
-          <div class="q-field__append q-field__marginal row no-wrap items-center q-anchor--skip"><i aria-hidden="true" role="presentation" class="q-select__dropdown-icon q-icon notranslate material-icons">arrow_drop_down</i></div>
+          <div class="q-field__append q-field__marginal row no-wrap items-center q-anchor--skip"><i aria-hidden="true" role="presentation" class="q-select__dropdown-icon notranslate material-icons q-icon">arrow_drop_down</i></div>
           <!---->
         </div>
         <div class="q-field__bottom row items-start q-field__bottom--animated">
@@ -2164,7 +2164,7 @@ exports[`Storyshots ActivitySeriesEdit time error 1`] = `
       </div>
     </label>
     <!----> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--standard q-field--float q-field--labeled q-field--with-bottom">
-      <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">group</i></div>
+      <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">group</i></div>
       <div class="q-field__inner relative-position col self-stretch">
         <div tabindex="-1" class="q-field__control relative-position row no-wrap">
           <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" aria-label="Max Slots" placeholder="unlimited" id="f_80808080-8080-4080-8080-808080808080" type="number" value="10" class="q-field__native q-placeholder" style="max-width:100px;">
@@ -2201,7 +2201,7 @@ exports[`Storyshots ActivitySeriesEdit time error 1`] = `
     </label>
     <div class="mentionable" style="position:relative;">
       <div class="relative-position q-mb-sm"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-textarea q-textarea--autogrow q-field--standard q-field--labeled q-field--with-bottom">
-          <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">info</i></div>
+          <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">info</i></div>
           <div class="q-field__inner relative-position col self-stretch">
             <div tabindex="-1" class="q-field__control relative-position row no-wrap">
               <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><textarea tabindex="0" rows="1" aria-label="Additional information" id="f_80808080-8080-4080-8080-808080808080" type="textarea" maxlength="500" class="q-field__native q-placeholder" style="min-height:100px;"></textarea>
@@ -2256,7 +2256,7 @@ exports[`Storyshots ActivitySeriesEdit weekly 1`] = `
 <div class="edit-box">
   <form class="q-gutter-y-lg" style="max-width:700px;">
     <!----> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-field--borderless q-field--float q-field--labeled q-field--auto-height">
-      <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-redo"> </i></div>
+      <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-redo q-icon"> </i></div>
       <div class="q-field__inner relative-position col self-stretch">
         <div tabindex="-1" class="q-field__control relative-position row no-wrap">
           <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip">
@@ -2289,7 +2289,7 @@ exports[`Storyshots ActivitySeriesEdit weekly 1`] = `
     </label>
     <div class="row q-mt-xs">
       <!----> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--standard q-field--float">
-        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">access_time</i></div>
+        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">access_time</i></div>
         <div class="q-field__inner relative-position col self-stretch">
           <div tabindex="-1" class="q-field__control relative-position row no-wrap">
             <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" size="3" id="f_80808080-8080-4080-8080-808080808080" type="text" value="12:00" class="q-field__native q-placeholder">
@@ -2297,7 +2297,7 @@ exports[`Storyshots ActivitySeriesEdit weekly 1`] = `
             </div>
           </div>
         </div>
-        <div class="q-field__after q-field__marginal row no-wrap items-center"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-ml-xs q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap" style="font-size:8px;"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon fas fa-plus"> </i></span></span></button></div>
+        <div class="q-field__after q-field__marginal row no-wrap items-center"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-ml-xs q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap" style="font-size:8px;"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="fas fa-plus q-icon"> </i></span></span></button></div>
       </label>
       <!---->
       <div class="q-ml-lg col-12 q-field__bottom">
@@ -2306,16 +2306,16 @@ exports[`Storyshots ActivitySeriesEdit weekly 1`] = `
         </div>
       </div>
     </div> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-select q-field--auto-height q-select--without-input q-select--without-chips q-select--multiple q-field--standard q-field--float q-field--labeled q-field--with-bottom">
-      <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">today</i></div>
+      <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">today</i></div>
       <div class="q-field__inner relative-position col self-stretch">
         <div tabindex="-1" class="q-field__control relative-position row no-wrap">
           <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip">
             <div class="q-field__native row items-center"><span>Tuesday</span>
-              <div id="f_80808080-8080-4080-8080-808080808080" tabindex="0" role="combobox" aria-multiselectable="true" aria-expanded="false" aria-owns="f_80808080-8080-4080-8080-808080808080_lb" aria-activedescendant="f_80808080-8080-4080-8080-808080808080_-1" class="q-select__focus-target"></div>
+              <div id="f_80808080-8080-4080-8080-808080808080" tabindex="0" role="combobox" aria-multiselectable="true" aria-expanded="false" aria-owns="f_80808080-8080-4080-8080-808080808080_lb" aria-activedescendant="f_80808080-8080-4080-8080-808080808080_-1" class="no-outline"></div>
             </div>
             <div class="q-field__label no-pointer-events absolute ellipsis">Weekdays</div>
           </div>
-          <div class="q-field__append q-field__marginal row no-wrap items-center q-anchor--skip"><i aria-hidden="true" role="presentation" class="q-select__dropdown-icon q-icon notranslate material-icons">arrow_drop_down</i></div>
+          <div class="q-field__append q-field__marginal row no-wrap items-center q-anchor--skip"><i aria-hidden="true" role="presentation" class="q-select__dropdown-icon notranslate material-icons q-icon">arrow_drop_down</i></div>
           <!---->
         </div>
         <div class="q-field__bottom row items-start q-field__bottom--animated">
@@ -2328,7 +2328,7 @@ exports[`Storyshots ActivitySeriesEdit weekly 1`] = `
       </div>
     </label>
     <!----> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--standard q-field--float q-field--labeled q-field--with-bottom">
-      <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">group</i></div>
+      <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">group</i></div>
       <div class="q-field__inner relative-position col self-stretch">
         <div tabindex="-1" class="q-field__control relative-position row no-wrap">
           <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" aria-label="Max Slots" placeholder="unlimited" id="f_80808080-8080-4080-8080-808080808080" type="number" value="10" class="q-field__native q-placeholder" style="max-width:100px;">
@@ -2365,7 +2365,7 @@ exports[`Storyshots ActivitySeriesEdit weekly 1`] = `
     </label>
     <div class="mentionable" style="position:relative;">
       <div class="relative-position q-mb-sm"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-textarea q-textarea--autogrow q-field--standard q-field--labeled q-field--with-bottom">
-          <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">info</i></div>
+          <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">info</i></div>
           <div class="q-field__inner relative-position col self-stretch">
             <div tabindex="-1" class="q-field__control relative-position row no-wrap">
               <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><textarea tabindex="0" rows="1" aria-label="Additional information" id="f_80808080-8080-4080-8080-808080808080" type="textarea" maxlength="500" class="q-field__native q-placeholder" style="min-height:100px;"></textarea>
@@ -2677,7 +2677,7 @@ exports[`Storyshots AddressPicker Default 1`] = `
     <div class="q-field__inner relative-position col self-stretch">
       <div tabindex="-1" class="q-field__control relative-position row no-wrap">
         <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip">
-          <div class="q-field__native row items-center"><input type="search" role="combobox" aria-multiselectable="false" aria-expanded="false" aria-owns="f_80808080-8080-4080-8080-808080808080_lb" aria-activedescendant="f_80808080-8080-4080-8080-808080808080_-1" placeholder="Search" id="f_80808080-8080-4080-8080-808080808080" tabindex="0" value="" class="q-field__input q-placeholder col q-field__input--padding"></div>
+          <div placeholder="Search" class="q-field__native row items-center"><input type="search" placeholder="Search" id="f_80808080-8080-4080-8080-808080808080" tabindex="0" role="combobox" aria-multiselectable="false" aria-expanded="false" aria-owns="f_80808080-8080-4080-8080-808080808080_lb" aria-activedescendant="f_80808080-8080-4080-8080-808080808080_-1" value="" class="q-field__input q-placeholder col q-field__input--padding"></div>
           <div class="q-field__label no-pointer-events absolute ellipsis"></div>
         </div>
         <div class="q-field__append q-field__marginal row no-wrap items-center"></div>
@@ -2701,7 +2701,7 @@ exports[`Storyshots Applications ApplicationForm 1`] = `
   <form>
     <div class="bg-white q-pt-sm q-pb-md q-px-sm rounded-borders">
       <div class="q-item q-item-type row no-wrap">
-        <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-fw fa-question"> </i></div>
+        <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="fas fa-fw fa-question q-icon"> </i></div>
         <div class="q-item__section column q-item__section--main justify-center">
           <div class="markdown">
             <p>Why do <strong>you</strong> want to join our group?</p>
@@ -2794,11 +2794,11 @@ exports[`Storyshots Applications ApplicationList 1`] = `
       <div class="q-expansion-item__container relative-position">
         <div tabindex="0" class="q-item q-item-type row no-wrap q-item--clickable q-link cursor-pointer q-focusable q-hoverable">
           <div tabindex="-1" class="q-focus-helper"></div>
-          <div class="q-item__section column q-item__section--avatar q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-archive"> </i></div>
+          <div class="q-item__section column q-item__section--avatar q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="fas fa-archive q-icon"> </i></div>
           <div class="q-item__section column q-item__section--main justify-center">
             <div class="q-item__label">Past applications</div>
           </div>
-          <div class="q-item__section column q-focusable relative-position cursor-pointer q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-expansion-item__toggle-icon q-icon notranslate material-icons">keyboard_arrow_down</i></div>
+          <div class="q-item__section column q-focusable relative-position cursor-pointer q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-expansion-item__toggle-icon notranslate material-icons q-icon">keyboard_arrow_down</i></div>
         </div>
         <transition-stub>
           <div class="q-expansion-item__content relative-position" style="display:none;"></div>
@@ -2813,25 +2813,25 @@ exports[`Storyshots Applications ApplicationList 1`] = `
 exports[`Storyshots Banners Banners 1`] = `
 <div>
   <div role="alert" class="q-banner row items-center k-banner bg-secondary text-white" style="min-height:unset;">
-    <div class="q-banner__avatar col-auto row items-center self-start"><i aria-hidden="true" role="presentation" class="q-icon fas fa-child" style="font-size:1.4em;"> </i></div>
+    <div class="q-banner__avatar col-auto row items-center self-start"><i aria-hidden="true" role="presentation" class="fas fa-child q-icon" style="font-size:1.4em;"> </i></div>
     <div class="q-banner__content col text-body2">
       This is a playground group, you can't break anything. Explore, click around and have fun!
     </div>
     <div class="q-banner__actions row items-center justify-end col-auto"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--rectangle q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><span class="block">Join another group</span></span></span></button></div>
   </div>
   <div role="alert" class="q-banner row items-center k-banner bg-warning text-white" style="min-height:unset;">
-    <div class="q-banner__avatar col-auto row items-center self-start"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons" style="font-size:1.4em;">report_problem</i></div>
+    <div class="q-banner__avatar col-auto row items-center self-start"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon" style="font-size:1.4em;">report_problem</i></div>
     <div class="q-banner__content col text-body2">
       Offline. Press here to reconnect.
     </div>
-    <div class="q-banner__actions row items-center justify-end col-auto"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--rectangle q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon notranslate material-icons">refresh</i></span></span></button></div>
+    <div class="q-banner__actions row items-center justify-end col-auto"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--rectangle q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="notranslate material-icons q-icon">refresh</i></span></span></button></div>
   </div>
 </div>
 `;
 
 exports[`Storyshots ChangePhoto empty 1`] = `
 <div class="edit-box k-change-photo"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-field--standard q-field--float q-field--labeled q-field--auto-height q-field--with-bottom">
-    <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-camera"> </i></div>
+    <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-camera q-icon"> </i></div>
     <div class="q-field__inner relative-position col self-stretch">
       <div tabindex="-1" class="q-field__control relative-position row no-wrap">
         <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip">
@@ -2867,7 +2867,7 @@ exports[`Storyshots ChangePhoto empty 1`] = `
 
 exports[`Storyshots ChangePhoto error 1`] = `
 <div class="edit-box k-change-photo"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-field--standard q-field--highlighted q-field--float q-field--labeled q-field--auto-height q-field--with-bottom q-field--error">
-    <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-camera"> </i></div>
+    <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-camera q-icon"> </i></div>
     <div class="q-field__inner relative-position col self-stretch">
       <div tabindex="-1" class="q-field__control relative-position row no-wrap text-negative">
         <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip">
@@ -2880,7 +2880,7 @@ exports[`Storyshots ChangePhoto error 1`] = `
           </div>
           <div class="q-field__label no-pointer-events absolute ellipsis"></div>
         </div>
-        <div class="q-field__append q-field__marginal row no-wrap items-center q-anchor--skip"><i aria-hidden="true" role="presentation" class="q-icon text-negative notranslate material-icons">error</i></div>
+        <div class="q-field__append q-field__marginal row no-wrap items-center q-anchor--skip"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon text-negative">error</i></div>
       </div>
       <div class="q-field__bottom row items-start q-field__bottom--animated">
         <transition-stub name="q-transition--field-message">
@@ -2904,7 +2904,7 @@ exports[`Storyshots ChangePhoto error 1`] = `
 
 exports[`Storyshots ChangePhoto pending 1`] = `
 <div class="edit-box k-change-photo"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-field--standard q-field--float q-field--labeled q-field--auto-height q-field--with-bottom">
-    <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-camera"> </i></div>
+    <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-camera q-icon"> </i></div>
     <div class="q-field__inner relative-position col self-stretch">
       <div tabindex="-1" class="q-field__control relative-position row no-wrap">
         <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip">
@@ -2940,7 +2940,7 @@ exports[`Storyshots ChangePhoto pending 1`] = `
 
 exports[`Storyshots ChangePhoto with photo 1`] = `
 <div class="edit-box k-change-photo"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-field--standard q-field--float q-field--labeled q-field--auto-height q-field--with-bottom">
-    <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-camera"> </i></div>
+    <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-camera q-icon"> </i></div>
     <div class="q-field__inner relative-position col self-stretch">
       <div tabindex="-1" class="q-field__control relative-position row no-wrap">
         <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip">
@@ -3152,7 +3152,7 @@ exports[`Storyshots ChatConversation closed 1`] = `
       <div class="q-item q-item-type row no-wrap q-mt-md">
         <div class="q-item__section column q-item__section--avatar q-item__section--side justify-center">
           <div class="q-avatar bg-grey-5 text-white q-chip--colored">
-            <div class="q-avatar__content row flex-center overflow-hidden"><i aria-hidden="true" role="presentation" class="q-icon fas fa-lock"> </i></div>
+            <div class="q-avatar__content row flex-center overflow-hidden"><i aria-hidden="true" role="presentation" class="fas fa-lock q-icon"> </i></div>
           </div>
         </div>
         <div class="q-item__section column q-item__section--main justify-center">
@@ -3782,7 +3782,7 @@ exports[`Storyshots ChatConversation message groups 1`] = `
           <!---->
           <div title="Dec 24, 2017, 11:59 AM" class="content">
             <div class="markdown">
-              <p>oh let me try something <img class="emoji" draggable="false" alt="🙂" src="https://twemoji.maxcdn.com/v/14.0.2/72x72/1f642.png" /></p>
+              <p>oh let me try something <img class="emoji" draggable="false" alt="🙂" src="https://twemoji.maxcdn.com/v/13.1.0/72x72/1f642.png" /></p>
             </div>
           </div>
           <!---->
@@ -4144,7 +4144,7 @@ exports[`Storyshots ChatConversation thread 1`] = `
 exports[`Storyshots CommunityFeed CommunityFeed 1`] = `
 <div tabindex="0" class="q-item q-item-type row no-wrap q-item--clickable q-link cursor-pointer q-focusable q-hoverable">
   <div tabindex="-1" class="q-focus-helper"></div>
-  <div class="q-item__section column text-center q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-icon fab fa-discourse fa-fw" style="font-size:1.1em;"> </i></div>
+  <div class="q-item__section column text-center q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="fab fa-discourse fa-fw q-icon" style="font-size:1.1em;"> </i></div>
   <div class="q-item__section column q-item__section--main justify-center">
     Discussions about Karrot
   </div>
@@ -4165,28 +4165,28 @@ exports[`Storyshots ConflictSetup create 1`] = `
       <div class="q-stepper__header row items-stretch justify-between q-stepper__header--standard-labels q-stepper__header--border">
         <div class="q-stepper__tab col-grow flex items-center no-wrap relative-position q-stepper__tab--active">
           <div tabindex="-1" class="q-focus-helper"></div>
-          <div class="q-stepper__dot row flex-center q-stepper__line relative-position"><span class="row flex-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">edit</i></span></div>
+          <div class="q-stepper__dot row flex-center q-stepper__line relative-position"><span class="row flex-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">edit</i></span></div>
           <div class="q-stepper__label q-stepper__line relative-position">
             <div class="q-stepper__title">Attention!</div>
           </div>
         </div>
         <div class="q-stepper__tab col-grow flex items-center no-wrap relative-position">
           <div tabindex="-1" class="q-focus-helper"></div>
-          <div class="q-stepper__dot row flex-center q-stepper__line relative-position"><span class="row flex-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-hand-holding-heart"> </i></span></div>
+          <div class="q-stepper__dot row flex-center q-stepper__line relative-position"><span class="row flex-center"><i aria-hidden="true" role="presentation" class="fas fa-hand-holding-heart q-icon"> </i></span></div>
           <div class="q-stepper__label q-stepper__line relative-position">
             <div class="q-stepper__title">Thank you!</div>
           </div>
         </div>
         <div class="q-stepper__tab col-grow flex items-center no-wrap relative-position">
           <div tabindex="-1" class="q-focus-helper"></div>
-          <div class="q-stepper__dot row flex-center q-stepper__line relative-position"><span class="row flex-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-info"> </i></span></div>
+          <div class="q-stepper__dot row flex-center q-stepper__line relative-position"><span class="row flex-center"><i aria-hidden="true" role="presentation" class="fas fa-info q-icon"> </i></span></div>
           <div class="q-stepper__label q-stepper__line relative-position">
             <div class="q-stepper__title">Info</div>
           </div>
         </div>
         <div class="q-stepper__tab col-grow flex items-center no-wrap relative-position">
           <div tabindex="-1" class="q-focus-helper"></div>
-          <div class="q-stepper__dot row flex-center q-stepper__line relative-position"><span class="row flex-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-pen-alt"> </i></span></div>
+          <div class="q-stepper__dot row flex-center q-stepper__line relative-position"><span class="row flex-center"><i aria-hidden="true" role="presentation" class="fas fa-pen-alt q-icon"> </i></span></div>
           <div class="q-stepper__label q-stepper__line relative-position">
             <div class="q-stepper__title">Statement</div>
           </div>
@@ -4233,7 +4233,7 @@ exports[`Storyshots ConversationCompose default 1`] = `
               <div class="q-field__inner relative-position col self-stretch">
                 <div tabindex="-1" class="q-field__control relative-position row no-wrap">
                   <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><textarea tabindex="0" rows="1" placeholder="Type here" id="f_80808080-8080-4080-8080-808080808080" type="textarea" class="q-field__native q-placeholder" style="min-height:unset;max-height:320px;"></textarea></div>
-                  <div class="q-field__append q-field__marginal row no-wrap items-center"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon fas fa-image"> </i></span></span></button>
+                  <div class="q-field__append q-field__marginal row no-wrap items-center"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="fas fa-image q-icon"> </i></span></span></button>
                     <!---->
                     <!---->
                   </div>
@@ -4289,7 +4289,7 @@ exports[`Storyshots ConversationCompose edit 1`] = `
               <div class="q-field__inner relative-position col self-stretch">
                 <div tabindex="-1" class="q-field__control relative-position row no-wrap">
                   <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><textarea tabindex="0" rows="1" placeholder="Type here" id="f_80808080-8080-4080-8080-808080808080" type="textarea" class="q-field__native q-placeholder" style="min-height:unset;max-height:320px;">existing text</textarea></div>
-                  <div class="q-field__append q-field__marginal row no-wrap items-center"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon fas fa-image"> </i></span></span></button> <button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon fas fa-arrow-right"> </i></span></span></button> <button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon fas fa-times"> </i></span></span></button></div>
+                  <div class="q-field__append q-field__marginal row no-wrap items-center"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="fas fa-image q-icon"> </i></span></span></button> <button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="fas fa-arrow-right q-icon"> </i></span></span></button> <button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="fas fa-times q-icon"> </i></span></span></button></div>
                 </div>
                 <div class="q-field__bottom row items-start q-field__bottom--animated">
                   <transition-stub name="q-transition--field-message">
@@ -4342,11 +4342,11 @@ exports[`Storyshots ConversationCompose error 1`] = `
               <div class="q-field__inner relative-position col self-stretch">
                 <div tabindex="-1" class="q-field__control relative-position row no-wrap text-negative">
                   <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><textarea tabindex="0" rows="1" placeholder="Type here" id="f_80808080-8080-4080-8080-808080808080" type="textarea" class="q-field__native q-placeholder" style="min-height:unset;max-height:320px;"></textarea></div>
-                  <div class="q-field__append q-field__marginal row no-wrap items-center q-anchor--skip"><i aria-hidden="true" role="presentation" class="q-icon text-negative notranslate material-icons">error</i></div>
-                  <div class="q-field__append q-field__marginal row no-wrap items-center"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon fas fa-image"> </i></span></span></button>
+                  <div class="q-field__append q-field__marginal row no-wrap items-center"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="fas fa-image q-icon"> </i></span></span></button>
                     <!---->
                     <!---->
                   </div>
+                  <div class="q-field__append q-field__marginal row no-wrap items-center q-anchor--skip"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon text-negative">error</i></div>
                 </div>
                 <div class="q-field__bottom row items-start q-field__bottom--animated">
                   <transition-stub name="q-transition--field-message">
@@ -4401,7 +4401,7 @@ exports[`Storyshots ConversationCompose not participant 1`] = `
               <div class="q-field__inner relative-position col self-stretch">
                 <div tabindex="-1" class="q-field__control relative-position row no-wrap">
                   <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><textarea tabindex="0" rows="1" placeholder="Type here" id="f_80808080-8080-4080-8080-808080808080" type="textarea" class="q-field__native q-placeholder" style="min-height:unset;max-height:320px;"></textarea></div>
-                  <div class="q-field__append q-field__marginal row no-wrap items-center"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon fas fa-image"> </i></span></span></button>
+                  <div class="q-field__append q-field__marginal row no-wrap items-center"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="fas fa-image q-icon"> </i></span></span></button>
                     <!---->
                     <!---->
                   </div>
@@ -4457,13 +4457,13 @@ exports[`Storyshots ConversationCompose pending 1`] = `
               <div class="q-field__inner relative-position col self-stretch">
                 <div tabindex="-1" class="q-field__control relative-position row no-wrap">
                   <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><textarea tabindex="0" rows="1" placeholder="Type here" id="f_80808080-8080-4080-8080-808080808080" type="textarea" disabled="disabled" class="q-field__native q-placeholder" style="min-height:unset;max-height:320px;"></textarea></div>
-                  <div class="q-field__append q-field__marginal row no-wrap items-center q-anchor--skip"><svg focusable="false" width="1em" height="1em" viewBox="25 25 50 50" class="q-spinner q-spinner-mat">
-                      <circle cx="50" cy="50" r="20" fill="none" stroke="currentColor" stroke-width="5" stroke-miterlimit="10" class="path"></circle>
-                    </svg></div>
-                  <div class="q-field__append q-field__marginal row no-wrap items-center"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon fas fa-image"> </i></span></span></button>
+                  <div class="q-field__append q-field__marginal row no-wrap items-center"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="fas fa-image q-icon"> </i></span></span></button>
                     <!---->
                     <!---->
                   </div>
+                  <div class="q-field__append q-field__marginal row no-wrap items-center q-anchor--skip"><svg focusable="false" width="1em" height="1em" viewBox="25 25 50 50" class="q-spinner q-spinner-mat">
+                      <circle cx="50" cy="50" r="20" fill="none" stroke="currentColor" stroke-width="5" stroke-miterlimit="10" class="path"></circle>
+                    </svg></div>
                 </div>
                 <div class="q-field__bottom row items-start q-field__bottom--animated">
                   <transition-stub name="q-transition--field-message">
@@ -4512,7 +4512,7 @@ exports[`Storyshots ConversationCompose slim 1`] = `
               <div class="q-field__inner relative-position col self-stretch">
                 <div tabindex="-1" class="q-field__control relative-position row no-wrap">
                   <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><textarea tabindex="0" rows="1" placeholder="Type here" id="f_80808080-8080-4080-8080-808080808080" type="textarea" class="q-field__native q-placeholder" style="min-height:unset;max-height:320px;"></textarea></div>
-                  <div class="q-field__append q-field__marginal row no-wrap items-center"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon fas fa-image"> </i></span></span></button>
+                  <div class="q-field__append q-field__marginal row no-wrap items-center"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="fas fa-image q-icon"> </i></span></span></button>
                     <!---->
                     <!---->
                   </div>
@@ -4679,7 +4679,7 @@ exports[`Storyshots ConversationMessage via email 1`] = `
   <div class="q-item__section column q-item__section--main justify-center">
     <div class="q-item__label no-wrap k-message-meta"><a><span class="k-message-author text-bold text-secondary text-uppercase">User 79</span></a> <span class="message-date"><small class="text-weight-light"><div title="Dec 24, 2017, 12:00 PM">
   less than a minute ago
-</div></small></span> <i aria-hidden="true" role="presentation" title="This message was sent via e-mail" class="email-icon q-icon far fa-envelope"> </i></div>
+</div></small></span> <i aria-hidden="true" role="presentation" title="This message was sent via e-mail" class="email-icon far fa-envelope q-icon"> </i></div>
     <div class="content">
       <div class="markdown">
         <p>This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test. This is a test.</p>
@@ -4924,7 +4924,7 @@ exports[`Storyshots Detail activity 1`] = `
           <!---->
           December 24, 2017
         </div>
-      </div> <button tabindex="0" type="button" title="How do you want to receive notifications about new messages in this conversation/thread?" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round text-white q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense" style="font-size:14px;"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-icon fas fa-fw fa-envelope" style="font-size:1.4em;"> </i> <!----></span></span></button> <button tabindex="0" type="button" title="Close" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon notranslate material-icons">close</i></span></span></button>
+      </div> <button tabindex="0" type="button" title="How do you want to receive notifications about new messages in this conversation/thread?" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round text-white q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense" style="font-size:14px;"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="fas fa-fw fa-envelope q-icon" style="font-size:1.4em;"> </i> <!----></span></span></button> <button tabindex="0" type="button" title="Close" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="notranslate material-icons q-icon">close</i></span></span></button>
     </div>
     <div class="k-participant-list row">
       <div class="col"></div>
@@ -5128,7 +5128,7 @@ exports[`Storyshots Detail activity 1`] = `
                         <div class="q-field__inner relative-position col self-stretch">
                           <div tabindex="-1" class="q-field__control relative-position row no-wrap">
                             <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><textarea tabindex="0" rows="1" placeholder="Write a message..." id="f_80808080-8080-4080-8080-808080808080" type="textarea" class="q-field__native q-placeholder" style="min-height:unset;max-height:320px;"></textarea></div>
-                            <div class="q-field__append q-field__marginal row no-wrap items-center"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon fas fa-image"> </i></span></span></button>
+                            <div class="q-field__append q-field__marginal row no-wrap items-center"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="fas fa-image q-icon"> </i></span></span></button>
                               <!---->
                               <!---->
                             </div>
@@ -5191,11 +5191,11 @@ exports[`Storyshots Detail application 1`] = `
           <div text="User 104" seed="104" class="randomArt fill"></div>
         </a></div>
       <div class="column q-toolbar__title ellipsis">
-        <div><a><span></span></a> <small><i aria-hidden="true" role="presentation" class="q-icon fas fa-fw fa-hourglass-half"> </i></small></div>
+        <div><a><span></span></a> <small><i aria-hidden="true" role="presentation" class="fas fa-fw fa-hourglass-half q-icon"> </i></small></div>
         <div class="text-caption"><span>
             User 104
           </span></div>
-      </div> <button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon notranslate material-icons">help_outline</i></span></span></button> <button tabindex="0" type="button" title="How do you want to receive notifications about new messages in this conversation/thread?" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round text-white q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense" style="font-size:14px;"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-icon fas fa-fw fa-envelope" style="font-size:1.4em;"> </i> <!----></span></span></button> <button tabindex="0" type="button" title="Close" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon notranslate material-icons">close</i></span></span></button>
+      </div> <button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="notranslate material-icons q-icon">help_outline</i></span></span></button> <button tabindex="0" type="button" title="How do you want to receive notifications about new messages in this conversation/thread?" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round text-white q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense" style="font-size:14px;"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="fas fa-fw fa-envelope q-icon" style="font-size:1.4em;"> </i> <!----></span></span></button> <button tabindex="0" type="button" title="Close" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="notranslate material-icons q-icon">close</i></span></span></button>
     </div>
     <!---->
   </div>
@@ -5222,7 +5222,7 @@ exports[`Storyshots Detail application 1`] = `
             <div class="q-item__section column q-item__section--main justify-center">
               <div class="q-item__label">Initial questions and answers</div>
             </div>
-            <div class="q-item__section column q-focusable relative-position cursor-pointer q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-expansion-item__toggle-icon q-icon notranslate material-icons q-expansion-item__toggle-icon--rotated">keyboard_arrow_down</i></div>
+            <div class="q-item__section column q-focusable relative-position cursor-pointer q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-expansion-item__toggle-icon notranslate material-icons q-icon q-expansion-item__toggle-icon--rotated">keyboard_arrow_down</i></div>
           </div>
           <transition-stub>
             <div class="q-expansion-item__content relative-position">
@@ -5418,9 +5418,9 @@ exports[`Storyshots Detail application 1`] = `
               <!---->
             </div>
           </div>
-          <div class="q-btn-group row no-wrap q-btn-group--spread bg-grey-2 q-my-sm q-mx-md q-btn-group--flat"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-pa-sm q-btn--flat q-btn--rectangle text-positive q-btn--actionable q-focusable q-hoverable q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon fas fa-fw fa-check"> </i>
+          <div class="q-btn-group row no-wrap q-btn-group--spread bg-grey-2 q-my-sm q-mx-md q-btn-group--flat"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-pa-sm q-btn--flat q-btn--rectangle text-positive q-btn--actionable q-focusable q-hoverable q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="fas fa-fw fa-check q-icon"> </i>
           Accept
-        </span></span></button> <button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-pa-sm q-btn--flat q-btn--rectangle text-negative q-btn--actionable q-focusable q-hoverable q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon fas fa-fw fa-times"> </i>
+        </span></span></button> <button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-pa-sm q-btn--flat q-btn--rectangle text-negative q-btn--actionable q-focusable q-hoverable q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="fas fa-fw fa-times q-icon"> </i>
           Decline
         </span></span></button></div>
           <div filled="" square="" class="q-pb-md">
@@ -5433,7 +5433,7 @@ exports[`Storyshots Detail application 1`] = `
                         <div class="q-field__inner relative-position col self-stretch">
                           <div tabindex="-1" class="q-field__control relative-position row no-wrap">
                             <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><textarea tabindex="0" rows="1" placeholder="Write a message..." id="f_80808080-8080-4080-8080-808080808080" type="textarea" class="q-field__native q-placeholder" style="min-height:unset;max-height:320px;"></textarea></div>
-                            <div class="q-field__append q-field__marginal row no-wrap items-center"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon fas fa-image"> </i></span></span></button>
+                            <div class="q-field__append q-field__marginal row no-wrap items-center"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="fas fa-image q-icon"> </i></span></span></button>
                               <!---->
                               <!---->
                             </div>
@@ -5490,7 +5490,7 @@ exports[`Storyshots Detail private 1`] = `
         </a></div>
       <div class="q-toolbar__title ellipsis">
         User 105
-      </div> <button tabindex="0" type="button" title="How do you want to receive notifications about new messages in this conversation/thread?" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round text-white q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense" style="font-size:14px;"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-icon fas fa-fw fa-envelope" style="font-size:1.4em;"> </i> <!----></span></span></button> <button tabindex="0" type="button" title="Close" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon notranslate material-icons">close</i></span></span></button>
+      </div> <button tabindex="0" type="button" title="How do you want to receive notifications about new messages in this conversation/thread?" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round text-white q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense" style="font-size:14px;"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="fas fa-fw fa-envelope q-icon" style="font-size:1.4em;"> </i> <!----></span></span></button> <button tabindex="0" type="button" title="Close" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="notranslate material-icons q-icon">close</i></span></span></button>
     </div>
     <!---->
   </div>
@@ -5692,7 +5692,7 @@ exports[`Storyshots Detail private 1`] = `
                         <div class="q-field__inner relative-position col self-stretch">
                           <div tabindex="-1" class="q-field__control relative-position row no-wrap">
                             <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><textarea tabindex="0" rows="1" placeholder="Write a message..." id="f_80808080-8080-4080-8080-808080808080" type="textarea" class="q-field__native q-placeholder" style="min-height:unset;max-height:320px;"></textarea></div>
-                            <div class="q-field__append q-field__marginal row no-wrap items-center"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon fas fa-image"> </i></span></span></button>
+                            <div class="q-field__append q-field__marginal row no-wrap items-center"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="fas fa-image q-icon"> </i></span></span></button>
                               <!---->
                               <!---->
                             </div>
@@ -5754,10 +5754,10 @@ exports[`Storyshots Feedback ActivityFeedback 1`] = `
                   <div class="q-field__prepend q-field__marginal row no-wrap items-center"></div>
                   <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip">
                     <div class="q-field__native row items-center"><span>Aug 12, 2017, 8:00 AM (Griesheimer Markt)</span>
-                      <div id="f_80808080-8080-4080-8080-808080808080" tabindex="0" role="combobox" aria-multiselectable="false" aria-expanded="false" aria-owns="f_80808080-8080-4080-8080-808080808080_lb" aria-activedescendant="f_80808080-8080-4080-8080-808080808080_-1" class="q-select__focus-target"></div>
+                      <div id="f_80808080-8080-4080-8080-808080808080" tabindex="0" role="combobox" aria-multiselectable="false" aria-expanded="false" aria-owns="f_80808080-8080-4080-8080-808080808080_lb" aria-activedescendant="f_80808080-8080-4080-8080-808080808080_-1" class="no-outline"></div>
                     </div>
                   </div>
-                  <div class="q-field__append q-field__marginal row no-wrap items-center q-anchor--skip"><i aria-hidden="true" role="presentation" class="q-select__dropdown-icon q-icon notranslate material-icons">arrow_drop_down</i></div>
+                  <div class="q-field__append q-field__marginal row no-wrap items-center q-anchor--skip"><i aria-hidden="true" role="presentation" class="q-select__dropdown-icon notranslate material-icons q-icon">arrow_drop_down</i></div>
                   <!---->
                 </div>
               </div>
@@ -5932,7 +5932,7 @@ exports[`Storyshots Feedback AmountPicker 1`] = `
   <!---->
   <div class="content column no-wrap q-pl-lg q-pb-lg">
     <div class="row no-wrap items-center justify-between q-pt-xs">
-      <div class="col-9 text-bold q-py-md"></div> <button tabindex="0" type="button" title="Delete amount" class="q-btn q-btn-item non-selectable no-outline self-center q-my-xs q-mr-sm q-btn--flat q-btn--round text-red q-btn--actionable q-focusable q-hoverable q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-icon fas fa-times"> </i></span></span></button>
+      <div class="col-9 text-bold q-py-md"></div> <button tabindex="0" type="button" title="Delete amount" class="q-btn q-btn-item non-selectable no-outline self-center q-my-xs q-mr-sm q-btn--flat q-btn--round text-red q-btn--actionable q-focusable q-hoverable q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="fas fa-times q-icon"> </i></span></span></button>
     </div>
     <div class="content-body row no-wrap items-center"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-pr-lg q-input q-field--outlined q-field--float">
         <div class="q-field__inner relative-position col self-stretch">
@@ -6142,13 +6142,13 @@ exports[`Storyshots Feedback PlaceFeedback 1`] = `
           </circle>
         </svg></div>
       <div class="infoChips row no-wrap">
-        <div title="10 activities done" class="q-chip row inline no-wrap items-center bg-secondary text-white q-chip--colored q-chip--square"><i aria-hidden="true" role="presentation" class="q-chip__icon q-chip__icon--left q-icon fas fa-asterisk"> </i>
+        <div title="10 activities done" class="q-chip row inline no-wrap items-center bg-secondary text-white q-chip--colored q-chip--square"><i aria-hidden="true" role="presentation" class="q-chip__icon q-chip__icon--left fas fa-asterisk q-icon"> </i>
           <div class="q-chip__content col row no-wrap items-center q-anchor--skip"><strong class="q-ml-sm">10</strong></div>
         </div>
-        <div title="4 feedback entries given" class="q-chip row inline no-wrap items-center bg-secondary text-white q-chip--colored q-chip--square"><i aria-hidden="true" role="presentation" class="q-chip__icon q-chip__icon--left q-icon fas fa-reply"> </i>
+        <div title="4 feedback entries given" class="q-chip row inline no-wrap items-center bg-secondary text-white q-chip--colored q-chip--square"><i aria-hidden="true" role="presentation" class="q-chip__icon q-chip__icon--left fas fa-reply q-icon"> </i>
           <div class="q-chip__content col row no-wrap items-center q-anchor--skip"><strong class="q-ml-sm">4</strong></div>
         </div>
-        <div title="10 kg of food saved" class="q-chip row inline no-wrap items-center bg-secondary text-white q-chip--colored q-chip--square"><i aria-hidden="true" role="presentation" class="q-chip__icon q-chip__icon--left q-icon fas fa-weight"> </i>
+        <div title="10 kg of food saved" class="q-chip row inline no-wrap items-center bg-secondary text-white q-chip--colored q-chip--square"><i aria-hidden="true" role="presentation" class="q-chip__icon q-chip__icon--left fas fa-weight q-icon"> </i>
           <div class="q-chip__content col row no-wrap items-center q-anchor--skip"><strong class="q-ml-sm">10 kg</strong></div>
         </div>
       </div> <span>
@@ -6158,7 +6158,7 @@ exports[`Storyshots Feedback PlaceFeedback 1`] = `
   </div>
   <div class="k-feedback-list">
     <div><a>
-        <div class="q-pa-md notice bg-info q-card"><i aria-hidden="true" role="presentation" class="on-left q-icon fas fa-reply"> </i>
+        <div class="q-pa-md notice bg-info q-card"><i aria-hidden="true" role="presentation" class="on-left fas fa-reply q-icon"> </i>
           2 activities await your feedback
         </div>
       </a></div>
@@ -6370,7 +6370,7 @@ exports[`Storyshots Feedback PlaceFeedback 1`] = `
 exports[`Storyshots GroupEdit create 1`] = `
 <div class="q-card">
   <div class="edit-box k-change-photo"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-field--standard q-field--float q-field--labeled q-field--auto-height q-field--with-bottom">
-      <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-camera"> </i></div>
+      <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-camera q-icon"> </i></div>
       <div class="q-field__inner relative-position col self-stretch">
         <div tabindex="-1" class="q-field__control relative-position row no-wrap">
           <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip">
@@ -6407,7 +6407,7 @@ exports[`Storyshots GroupEdit create 1`] = `
       <h4 class="text-primary q-mt-none q-mb-lg">
         General
       </h4> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-mb-lg q-input q-field--outlined q-field--float q-field--labeled q-field--with-bottom">
-        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-fw fa-star"> </i></div>
+        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-fw fa-star q-icon"> </i></div>
         <div class="q-field__inner relative-position col self-stretch">
           <div tabindex="-1" class="q-field__control relative-position row no-wrap">
             <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" data-autofocus="true" aria-label="Title of this group" id="f_80808080-8080-4080-8080-808080808080" autocomplete="off" type="text" value="05_testgroup" class="q-field__native q-placeholder">
@@ -6423,7 +6423,7 @@ exports[`Storyshots GroupEdit create 1`] = `
       </label>
       <div class="q-mb-lg">
         <div class="relative-position q-mb-sm"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-textarea q-textarea--autogrow q-field--outlined q-field--float q-field--labeled q-field--with-bottom">
-            <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-fw fa-question"> </i></div>
+            <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-fw fa-question q-icon"> </i></div>
             <div class="q-field__inner relative-position col self-stretch">
               <div tabindex="-1" class="q-field__control relative-position row no-wrap">
                 <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><textarea tabindex="0" rows="1" aria-label="Public group information" id="f_80808080-8080-4080-8080-808080808080" type="textarea" class="q-field__native q-placeholder" style="min-height:100px;">This is the public description
@@ -6446,7 +6446,7 @@ It would make sense if it was markdown
       </div>
       <div class="mentionable q-mb-lg" style="position:relative;">
         <div class="relative-position q-mb-sm"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-textarea q-textarea--autogrow q-field--outlined q-field--labeled q-field--with-bottom">
-            <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-fw fa-address-card"> </i></div>
+            <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-fw fa-address-card q-icon"> </i></div>
             <div class="q-field__inner relative-position col self-stretch">
               <div tabindex="-1" class="q-field__control relative-position row no-wrap">
                 <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><textarea tabindex="0" rows="1" aria-label="Group description, visible for members" id="f_80808080-8080-4080-8080-808080808080" type="textarea" class="q-field__native q-placeholder" style="min-height:100px;"></textarea>
@@ -6483,17 +6483,17 @@ It would make sense if it was markdown
       </div>
       <h4 class="text-primary q-mt-xl q-mb-lg">
         Location
-        <button tabindex="0" type="button" title="" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round text-green q-btn--actionable q-focusable q-hoverable q-btn--wrap" style="font-size:10px;"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon fas fa-question-circle"> </i><!----></span></span></button>
+        <button tabindex="0" type="button" title="" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round text-green q-btn--actionable q-focusable q-hoverable q-btn--wrap" style="font-size:10px;"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="fas fa-question-circle q-icon"> </i><!----></span></span></button>
       </h4>
       <div class="q-mb-lg"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-select q-field--auto-height q-select--with-input q-select--without-chips q-select--single q-field--outlined q-field--float q-field--labeled q-field--with-bottom">
-          <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-fw fa-map-marker"> </i></div>
+          <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-fw fa-map-marker q-icon"> </i></div>
           <div class="q-field__inner relative-position col self-stretch">
             <div tabindex="-1" class="q-field__control relative-position row no-wrap">
               <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip">
-                <div class="q-field__native row items-center"><input type="search" role="combobox" aria-multiselectable="false" aria-expanded="false" aria-owns="f_80808080-8080-4080-8080-808080808080_lb" aria-activedescendant="f_80808080-8080-4080-8080-808080808080_-1" placeholder="Search" id="f_80808080-8080-4080-8080-808080808080" tabindex="0" value="Darmstadt, Regierungsbezirk Darmstadt, Hessen, Deutschland" class="q-field__input q-placeholder col q-field__input--padding"></div>
+                <div placeholder="Search" class="q-field__native row items-center"><input type="search" placeholder="Search" id="f_80808080-8080-4080-8080-808080808080" tabindex="0" role="combobox" aria-multiselectable="false" aria-expanded="false" aria-owns="f_80808080-8080-4080-8080-808080808080_lb" aria-activedescendant="f_80808080-8080-4080-8080-808080808080_-1" value="Darmstadt, Regierungsbezirk Darmstadt, Hessen, Deutschland" class="q-field__input q-placeholder col q-field__input--padding"></div>
                 <div class="q-field__label no-pointer-events absolute ellipsis">Address</div>
               </div>
-              <div class="q-field__append q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="cursor-pointer q-icon notranslate material-icons">cancel</i></div>
+              <div class="q-field__append q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="cursor-pointer notranslate material-icons q-icon">cancel</i></div>
             </div>
             <div class="q-field__bottom row items-start q-field__bottom--animated">
               <transition-stub name="q-transition--field-message">
@@ -6506,14 +6506,14 @@ It would make sense if it was markdown
           <!---->
         </div>
       </div> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-mb-lg q-select q-field--auto-height q-select--with-input q-select--without-chips q-select--single q-field--outlined q-field--labeled q-field--with-bottom">
-        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-fw fa-globe"> </i></div>
+        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-fw fa-globe q-icon"> </i></div>
         <div class="q-field__inner relative-position col self-stretch">
           <div tabindex="-1" class="q-field__control relative-position row no-wrap">
             <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip">
-              <div class="q-field__native row items-center"><input type="search" role="combobox" aria-multiselectable="false" aria-expanded="false" aria-owns="f_80808080-8080-4080-8080-808080808080_lb" aria-activedescendant="f_80808080-8080-4080-8080-808080808080_-1" id="f_80808080-8080-4080-8080-808080808080" tabindex="0" value="" class="q-field__input q-placeholder col"></div>
+              <div class="q-field__native row items-center"><input type="search" id="f_80808080-8080-4080-8080-808080808080" tabindex="0" role="combobox" aria-multiselectable="false" aria-expanded="false" aria-owns="f_80808080-8080-4080-8080-808080808080_lb" aria-activedescendant="f_80808080-8080-4080-8080-808080808080_-1" value="" class="q-field__input q-placeholder col"></div>
               <div class="q-field__label no-pointer-events absolute ellipsis">Time zone of group</div>
             </div>
-            <div class="q-field__append q-field__marginal row no-wrap items-center q-anchor--skip"><i aria-hidden="true" role="presentation" class="q-select__dropdown-icon q-icon notranslate material-icons">arrow_drop_down</i></div>
+            <div class="q-field__append q-field__marginal row no-wrap items-center q-anchor--skip"><i aria-hidden="true" role="presentation" class="q-select__dropdown-icon notranslate material-icons q-icon">arrow_drop_down</i></div>
             <!---->
           </div>
           <div class="q-field__bottom row items-start q-field__bottom--animated">
@@ -6525,11 +6525,11 @@ It would make sense if it was markdown
       </label>
       <h4 class="text-primary q-mt-xl q-mb-lg">
         New Members Signup
-        <button tabindex="0" type="button" title="" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round text-green q-btn--actionable q-focusable q-hoverable q-btn--wrap" style="font-size:10px;"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon fas fa-question-circle"> </i><!----></span></span></button>
+        <button tabindex="0" type="button" title="" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round text-green q-btn--actionable q-focusable q-hoverable q-btn--wrap" style="font-size:10px;"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="fas fa-question-circle q-icon"> </i><!----></span></span></button>
       </h4>
       <div class="q-mb-lg">
         <div class="relative-position q-mb-sm"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-textarea q-textarea--autogrow q-field--outlined q-field--float q-field--labeled q-field--with-bottom">
-            <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-fw fa-question"> </i></div>
+            <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-fw fa-question q-icon"> </i></div>
             <div class="q-field__inner relative-position col self-stretch">
               <div tabindex="-1" class="q-field__control relative-position row no-wrap">
                 <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><textarea tabindex="0" rows="1" aria-label="Questions for people who want to join this group" id="f_80808080-8080-4080-8080-808080808080" type="textarea" class="q-field__native q-placeholder" style="min-height:100px;">Hello stranger! :smiley: :wave: Do you want to help us save all the good food from being wasted? Please tell us how you plan to contribute and who or what made you aware of our existence! Looking forward to working with you!</textarea>
@@ -6548,7 +6548,7 @@ It would make sense if it was markdown
       </div>
       <div class="q-mb-lg">
         <div class="relative-position q-mb-sm"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-textarea q-textarea--autogrow q-field--outlined q-field--labeled q-field--with-bottom">
-            <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-fw fa-address-card"> </i></div>
+            <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-fw fa-address-card q-icon"> </i></div>
             <div class="q-field__inner relative-position col self-stretch">
               <div tabindex="-1" class="q-field__control relative-position row no-wrap">
                 <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><textarea tabindex="0" rows="1" aria-label="Welcome message sent to new members" id="f_80808080-8080-4080-8080-808080808080" type="textarea" class="q-field__native q-placeholder" style="min-height:100px;"></textarea>
@@ -6585,7 +6585,7 @@ exports[`Storyshots GroupGallery signup view 1`] = `
   </div>
   <div class="sidebar expanded"><object tabindex="-1" type="text/html" data="about:blank" aria-hidden="true" style="display:block;position:absolute;top:0;left:0;right:0;bottom:0;height:100%;width:100%;overflow:hidden;pointer-events:none;z-index:-1;"></object>
     <div role="alert" class="q-banner row items-center q-ma-sm bg-warning text-white shadow-2" style="min-height:unset;">
-      <div class="q-banner__avatar col-auto row items-center self-start"><i aria-hidden="true" role="presentation" class="q-icon text-white notranslate material-icons" style="font-size:24px;">star</i></div>
+      <div class="q-banner__avatar col-auto row items-center self-start"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon text-white" style="font-size:24px;">star</i></div>
       <div class="q-banner__content col text-body2"> <span>You are currently logged out. <a class="underline">
           Log in to see your groups!
         </a></span></div>
@@ -6599,7 +6599,7 @@ exports[`Storyshots GroupGallery signup view 1`] = `
       <div class="col"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-pl-sm q-input q-field--filled q-field--dense">
           <div class="q-field__inner relative-position col self-stretch">
             <div tabindex="-1" class="q-field__control relative-position row no-wrap">
-              <div class="q-field__prepend q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">search</i></div>
+              <div class="q-field__prepend q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">search</i></div>
               <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" placeholder="Search" id="f_80808080-8080-4080-8080-808080808080" type="text" value="" class="q-field__native q-placeholder"></div>
             </div>
           </div>
@@ -6730,7 +6730,7 @@ exports[`Storyshots GroupGallery switch and explore 1`] = `
       <div class="col"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-pl-sm q-input q-field--filled q-field--dense">
           <div class="q-field__inner relative-position col self-stretch">
             <div tabindex="-1" class="q-field__control relative-position row no-wrap">
-              <div class="q-field__prepend q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">search</i></div>
+              <div class="q-field__prepend q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">search</i></div>
               <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" placeholder="Search" id="f_80808080-8080-4080-8080-808080808080" type="text" value="" class="q-field__native q-placeholder"></div>
             </div>
           </div>
@@ -6789,7 +6789,7 @@ exports[`Storyshots GroupGallery switch and explore 1`] = `
               <div class="overlay"></div>
             </div>
             <hr aria-orientation="horizontal" class="q-separator q-separator q-separator--horizontal">
-            <div class="q-card__actions q-card__actions--horiz row justify-start"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--rectangle q-btn--actionable q-focusable q-hoverable q-btn--wrap" style="font-size:10px;"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon fas fa-home"> </i><!----></span></span></button> <button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--rectangle q-btn--actionable q-focusable q-hoverable q-btn--wrap" style="font-size:10px;"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon fas fa-info-circle"> </i><!----></span></span></button></div>
+            <div class="q-card__actions q-card__actions--horiz row justify-start"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--rectangle q-btn--actionable q-focusable q-hoverable q-btn--wrap" style="font-size:10px;"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="fas fa-home q-icon"> </i><!----></span></span></button> <button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--rectangle q-btn--actionable q-focusable q-hoverable q-btn--wrap" style="font-size:10px;"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="fas fa-info-circle q-icon"> </i><!----></span></span></button></div>
           </div>
         </div>
         <div class="inline-block" style="width:100%;">
@@ -6815,7 +6815,7 @@ exports[`Storyshots GroupGallery switch and explore 1`] = `
               <div class="overlay"></div>
             </div>
             <hr aria-orientation="horizontal" class="q-separator q-separator q-separator--horizontal">
-            <div class="q-card__actions q-card__actions--horiz row justify-start"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--rectangle q-btn--actionable q-focusable q-hoverable q-btn--wrap" style="font-size:10px;"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon fas fa-home"> </i><!----></span></span></button> <button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--rectangle q-btn--actionable q-focusable q-hoverable q-btn--wrap" style="font-size:10px;"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon fas fa-info-circle"> </i><!----></span></span></button></div>
+            <div class="q-card__actions q-card__actions--horiz row justify-start"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--rectangle q-btn--actionable q-focusable q-hoverable q-btn--wrap" style="font-size:10px;"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="fas fa-home q-icon"> </i><!----></span></span></button> <button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--rectangle q-btn--actionable q-focusable q-hoverable q-btn--wrap" style="font-size:10px;"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="fas fa-info-circle q-icon"> </i><!----></span></span></button></div>
           </div>
         </div>
       </div>
@@ -6943,7 +6943,7 @@ exports[`Storyshots GroupGalleryCard isMember = false 1`] = `
 exports[`Storyshots GroupGalleryCard isMember = false, application pending 1`] = `
 <div class="inline-block">
   <div class="groupPreviewCard relative-position q-card application">
-    <div role="alert" class="q-pl-sm q-pt-xs q-pb-xs z-top q-badge flex inline items-center no-wrap q-badge--single-line bg-blue q-badge--floating"><i aria-hidden="true" role="presentation" class="q-icon fas fa-hourglass-half"> </i></div>
+    <div role="alert" class="q-pl-sm q-pt-xs q-pb-xs z-top q-badge flex inline items-center no-wrap q-badge--single-line bg-blue q-badge--floating"><i aria-hidden="true" role="presentation" class="fas fa-hourglass-half q-icon"> </i></div>
     <!---->
     <div class="photo text-white relative-position row justify-center">
       <div seed="61" type="circles" class="full-height"></div>
@@ -6993,7 +6993,7 @@ exports[`Storyshots GroupGalleryCard isMember = true 1`] = `
       <div class="overlay"></div>
     </div>
     <hr aria-orientation="horizontal" class="q-separator q-separator q-separator--horizontal">
-    <div class="q-card__actions q-card__actions--horiz row justify-start"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--rectangle q-btn--actionable q-focusable q-hoverable q-btn--wrap" style="font-size:10px;"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon fas fa-home"> </i><!----></span></span></button> <button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--rectangle q-btn--actionable q-focusable q-hoverable q-btn--wrap" style="font-size:10px;"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon fas fa-info-circle"> </i><!----></span></span></button></div>
+    <div class="q-card__actions q-card__actions--horiz row justify-start"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--rectangle q-btn--actionable q-focusable q-hoverable q-btn--wrap" style="font-size:10px;"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="fas fa-home q-icon"> </i><!----></span></span></button> <button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--rectangle q-btn--actionable q-focusable q-hoverable q-btn--wrap" style="font-size:10px;"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="fas fa-info-circle q-icon"> </i><!----></span></span></button></div>
   </div>
 </div>
 `;
@@ -7048,7 +7048,7 @@ exports[`Storyshots GroupPreviewUI archived 1`] = `
     <div class="q-card__actions q-card__actions--horiz row justify-start">
       <div style="width:100%;">
         <div role="alert" class="q-banner row items-center bg-info">
-          <div class="q-banner__avatar col-auto row items-center self-start"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons" style="font-size:24px;">info</i></div>
+          <div class="q-banner__avatar col-auto row items-center self-start"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon" style="font-size:24px;">info</i></div>
           <div class="q-banner__content col text-body2">
             This group doesn't have any members. If you would like to revive it, contact the site administrators!
           </div>
@@ -7081,7 +7081,7 @@ exports[`Storyshots GroupPreviewUI member 1`] = `
     </div>
     <hr aria-orientation="horizontal" class="q-separator q-separator q-separator--horizontal">
     <div class="q-card__actions q-card__actions--horiz row justify-start">
-      <div style="width:100%;"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--rectangle q-btn--actionable q-focusable q-hoverable q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-icon fas fa-home"> </i> <!----></span></span></button></div>
+      <div style="width:100%;"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--rectangle q-btn--actionable q-focusable q-hoverable q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="fas fa-home q-icon"> </i> <!----></span></span></button></div>
     </div>
   </div>
 </div>
@@ -7143,7 +7143,7 @@ exports[`Storyshots GroupPreviewUI not member, application needed, email not ver
     <div class="q-card__actions q-card__actions--horiz row justify-start">
       <div style="width:100%;">
         <div role="alert" class="q-banner row items-center bg-info">
-          <div class="q-banner__avatar col-auto row items-center self-start"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons" style="font-size:24px;">info</i></div>
+          <div class="q-banner__avatar col-auto row items-center self-start"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon" style="font-size:24px;">info</i></div>
           <div class="q-banner__content col text-body2">
             By joining this group, your profile data will become visible to other group members.
           </div>
@@ -7185,7 +7185,7 @@ exports[`Storyshots GroupPreviewUI not member, application needed, email verifie
     <div class="q-card__actions q-card__actions--horiz row justify-start">
       <div style="width:100%;">
         <div role="alert" class="q-banner row items-center bg-info">
-          <div class="q-banner__avatar col-auto row items-center self-start"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons" style="font-size:24px;">info</i></div>
+          <div class="q-banner__avatar col-auto row items-center self-start"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon" style="font-size:24px;">info</i></div>
           <div class="q-banner__content col text-body2">
             By joining this group, your profile data will become visible to other group members.
           </div>
@@ -7227,7 +7227,7 @@ exports[`Storyshots GroupPreviewUI not member, open group 1`] = `
     <div class="q-card__actions q-card__actions--horiz row justify-start">
       <div style="width:100%;">
         <div role="alert" class="q-banner row items-center bg-info">
-          <div class="q-banner__avatar col-auto row items-center self-start"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons" style="font-size:24px;">info</i></div>
+          <div class="q-banner__avatar col-auto row items-center self-start"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon" style="font-size:24px;">info</i></div>
           <div class="q-banner__content col text-body2">
             By joining this group, your profile data will become visible to other group members.
           </div>
@@ -7270,11 +7270,11 @@ exports[`Storyshots GroupPreviewUI not member, pending application 1`] = `
       <div style="width:100%;">
         <!---->
         <div role="alert" class="q-banner row items-center bg-blue text-white">
-          <div class="q-banner__avatar col-auto row items-center self-start"><i aria-hidden="true" role="presentation" class="q-icon text-white notranslate material-icons" style="font-size:24px;">info</i></div>
+          <div class="q-banner__avatar col-auto row items-center self-start"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon text-white" style="font-size:24px;">info</i></div>
           <div class="q-banner__content col text-body2">
             Your application is pending!
           </div>
-          <div class="q-banner__actions row items-center justify-end col-auto"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--rectangle q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon on-left fas fa-fw fa-comments"> </i><span class="block">Open</span></span></span></button> <button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--rectangle q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon on-left fas fa-fw fa-trash-alt"> </i><span class="block">Withdraw</span></span></span></button></div>
+          <div class="q-banner__actions row items-center justify-end col-auto"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--rectangle q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="fas fa-fw fa-comments q-icon on-left"> </i><span class="block">Open</span></span></span></button> <button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--rectangle q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="fas fa-fw fa-trash-alt q-icon on-left"> </i><span class="block">Withdraw</span></span></span></button></div>
         </div>
         <!---->
         <!---->
@@ -7293,7 +7293,7 @@ exports[`Storyshots GroupPreviewUI not member, playground 1`] = `
       <div class="absolute-bottom k-media-overlay q-pa-md">
         <div class="ellipsis"><span class="row group items-start text-h6">
             Group 75
-            <i aria-hidden="true" role="presentation" class="q-icon fas fa-child"> </i></span> <span class="text-subtitle2">
+            <i aria-hidden="true" role="presentation" class="fas fa-child q-icon"> </i></span> <span class="text-subtitle2">
             1 Member
           </span></div>
       </div>
@@ -7309,7 +7309,7 @@ exports[`Storyshots GroupPreviewUI not member, playground 1`] = `
     <div class="q-card__actions q-card__actions--horiz row justify-start">
       <div style="width:100%;">
         <div role="alert" class="q-banner row items-center bg-info">
-          <div class="q-banner__avatar col-auto row items-center self-start"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons" style="font-size:24px;">info</i></div>
+          <div class="q-banner__avatar col-auto row items-center self-start"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon" style="font-size:24px;">info</i></div>
           <div class="q-banner__content col text-body2">
             By joining this group, your profile data will become visible to other group members.
           </div>
@@ -7351,7 +7351,7 @@ exports[`Storyshots GroupPreviewUI pending join 1`] = `
     <div class="q-card__actions q-card__actions--horiz row justify-start">
       <div style="width:100%;">
         <div role="alert" class="q-banner row items-center bg-info">
-          <div class="q-banner__avatar col-auto row items-center self-start"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons" style="font-size:24px;">info</i></div>
+          <div class="q-banner__avatar col-auto row items-center self-start"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon" style="font-size:24px;">info</i></div>
           <div class="q-banner__content col text-body2">
             By joining this group, your profile data will become visible to other group members.
           </div>
@@ -7387,7 +7387,7 @@ exports[`Storyshots GroupPreviewUI without public description 1`] = `
       </span></div>
     <hr aria-orientation="horizontal" class="q-separator q-separator q-separator--horizontal">
     <div class="q-card__actions q-card__actions--horiz row justify-start">
-      <div style="width:100%;"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--rectangle q-btn--actionable q-focusable q-hoverable q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-icon fas fa-home"> </i> <!----></span></span></button></div>
+      <div style="width:100%;"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--rectangle q-btn--actionable q-focusable q-hoverable q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="fas fa-home q-icon"> </i> <!----></span></span></button></div>
     </div>
   </div>
 </div>
@@ -7788,7 +7788,7 @@ exports[`Storyshots History List Default 1`] = `
 exports[`Storyshots Invitations InvitationsForm 1`] = `
 <div>
   <form><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--standard q-field--with-bottom">
-      <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-envelope"> </i></div>
+      <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-envelope q-icon"> </i></div>
       <div class="q-field__inner relative-position col self-stretch">
         <div tabindex="-1" class="q-field__control relative-position row no-wrap">
           <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" autocorrect="off" autocapitalize="off" spellcheck="false" id="f_80808080-8080-4080-8080-808080808080" type="email" class="q-field__native q-placeholder"></div>
@@ -7802,7 +7802,7 @@ exports[`Storyshots Invitations InvitationsForm 1`] = `
         </div>
       </div>
     </label>
-    <div class="row justify-end"><button tabindex="0" type="submit" class="q-btn q-btn-item non-selectable no-outline q-btn--standard q-btn--rectangle bg-secondary text-white q-btn--actionable q-focusable q-hoverable q-btn--wrap" style="min-width:5.5em;"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-icon fas fa-paper-plane"> </i> <!----></span></span>
+    <div class="row justify-end"><button tabindex="0" type="submit" class="q-btn q-btn-item non-selectable no-outline q-btn--standard q-btn--rectangle bg-secondary text-white q-btn--actionable q-focusable q-hoverable q-btn--wrap" style="min-width:5.5em;"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="fas fa-paper-plane q-icon"> </i> <!----></span></span>
         <transition-stub name="q-transition--fade"></transition-stub>
       </button></div>
   </form>
@@ -7961,11 +7961,11 @@ exports[`Storyshots Issues IssueList 1`] = `
       <div class="q-expansion-item__container relative-position">
         <div tabindex="0" class="q-item q-item-type row no-wrap q-item--clickable q-link cursor-pointer q-focusable q-hoverable">
           <div tabindex="-1" class="q-focus-helper"></div>
-          <div class="q-item__section column q-item__section--avatar q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-archive"> </i></div>
+          <div class="q-item__section column q-item__section--avatar q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="fas fa-archive q-icon"> </i></div>
           <div class="q-item__section column q-item__section--main justify-center">
             <div class="q-item__label">Past issues</div>
           </div>
-          <div class="q-item__section column q-focusable relative-position cursor-pointer q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-expansion-item__toggle-icon q-icon notranslate material-icons">keyboard_arrow_down</i></div>
+          <div class="q-item__section column q-focusable relative-position cursor-pointer q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-expansion-item__toggle-icon notranslate material-icons q-icon">keyboard_arrow_down</i></div>
         </div>
         <transition-stub>
           <div class="q-expansion-item__content relative-position" style="display:none;"></div>
@@ -7978,7 +7978,7 @@ exports[`Storyshots Issues IssueList 1`] = `
 
 exports[`Storyshots Issues IssueVote - not voted yet 1`] = `
 <div>
-  <div class="float-right"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon notranslate material-icons">help_outline</i></span></span></button></div>
+  <div class="float-right"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="notranslate material-icons q-icon">help_outline</i></span></span></button></div>
   <div class="text-h6 q-mb-md">
     How do you want to proceed with the ongoing conflict with User 43?
   </div>
@@ -8087,7 +8087,7 @@ exports[`Storyshots Issues IssueVote - not voted yet 1`] = `
 
 exports[`Storyshots Issues IssueVote - vote 1`] = `
 <div>
-  <div class="float-right"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon notranslate material-icons">help_outline</i></span></span></button></div>
+  <div class="float-right"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="notranslate material-icons q-icon">help_outline</i></span></span></button></div>
   <div class="text-h6 q-mb-md">
     How do you want to proceed with the ongoing conflict with User 41?
   </div>
@@ -8209,7 +8209,7 @@ exports[`Storyshots Issues history item 1`] = `
           </div>
         </div>
       </div>
-      <div class="q-item__section column q-focusable relative-position cursor-pointer q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-expansion-item__toggle-icon q-icon notranslate material-icons">keyboard_arrow_down</i></div>
+      <div class="q-item__section column q-focusable relative-position cursor-pointer q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-expansion-item__toggle-icon notranslate material-icons q-icon">keyboard_arrow_down</i></div>
     </div>
     <transition-stub>
       <div class="q-expansion-item__content relative-position" style="display:none;">
@@ -8230,7 +8230,7 @@ exports[`Storyshots Issues history item 1`] = `
             </div>
           </div>
           <div class="q-item q-item-type row no-wrap text-secondary">
-            <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-icon text-secondary fas fa-smile"> </i></div>
+            <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="fas fa-smile q-icon text-secondary"> </i></div>
             <div class="q-item__section column q-item__section--main justify-center">
               User 39 gets removed from asdf
             </div>
@@ -8239,7 +8239,7 @@ exports[`Storyshots Issues history item 1`] = `
             </div>
           </div>
           <div class="q-item q-item-type row no-wrap">
-            <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-icon text-primary fas fa-meh"> </i></div>
+            <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="fas fa-meh q-icon text-primary"> </i></div>
             <div class="q-item__section column q-item__section--main justify-center">
               Further discussion: extend time by starting another voting
             </div>
@@ -8248,7 +8248,7 @@ exports[`Storyshots Issues history item 1`] = `
             </div>
           </div>
           <div class="q-item q-item-type row no-wrap">
-            <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-icon text-primary fas fa-meh"> </i></div>
+            <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="fas fa-meh q-icon text-primary"> </i></div>
             <div class="q-item__section column q-item__section--main justify-center">
               No change: User 39 stays in asdf
             </div>
@@ -8281,7 +8281,7 @@ exports[`Storyshots Issues results - expelled 1`] = `
     </div>
   </div>
   <div class="q-item q-item-type row no-wrap text-secondary">
-    <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-icon text-secondary fas fa-smile"> </i></div>
+    <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="fas fa-smile q-icon text-secondary"> </i></div>
     <div class="q-item__section column q-item__section--main justify-center">
       User 39 gets removed from asdf
     </div>
@@ -8290,7 +8290,7 @@ exports[`Storyshots Issues results - expelled 1`] = `
     </div>
   </div>
   <div class="q-item q-item-type row no-wrap">
-    <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-icon text-primary fas fa-meh"> </i></div>
+    <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="fas fa-meh q-icon text-primary"> </i></div>
     <div class="q-item__section column q-item__section--main justify-center">
       Further discussion: extend time by starting another voting
     </div>
@@ -8299,7 +8299,7 @@ exports[`Storyshots Issues results - expelled 1`] = `
     </div>
   </div>
   <div class="q-item q-item-type row no-wrap">
-    <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-icon text-primary fas fa-meh"> </i></div>
+    <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="fas fa-meh q-icon text-primary"> </i></div>
     <div class="q-item__section column q-item__section--main justify-center">
       No change: User 39 stays in asdf
     </div>
@@ -8317,7 +8317,7 @@ exports[`Storyshots KAbout KAbout 1`] = `
   </div>
   <div class="q-mt-md q-list"><a tabindex="0" href="https://community.karrot.world/t/how-to-get-involved-onboarding-into-the-karrot-team/661" target="_blank" rel="noopener noreferrer" class="q-item q-item-type row no-wrap q-item--clickable q-link cursor-pointer q-focusable q-hoverable">
       <div tabindex="-1" class="q-focus-helper"></div>
-      <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-users"> </i></div>
+      <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="fas fa-users q-icon"> </i></div>
       <div class="q-item__section column q-item__section--main justify-center">
         <div class="q-item__label">
           How to Get Involved
@@ -8325,7 +8325,7 @@ exports[`Storyshots KAbout KAbout 1`] = `
       </div>
     </a> <a tabindex="0" href="https://github.com/karrot-dev/karrot-frontend" target="_blank" rel="noopener noreferrer" class="q-item q-item-type row no-wrap q-item--clickable q-link cursor-pointer q-focusable q-hoverable">
       <div tabindex="-1" class="q-focus-helper"></div>
-      <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-icon fab fa-fw fa-github"> </i></div>
+      <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="fab fa-fw fa-github q-icon"> </i></div>
       <div class="q-item__section column q-item__section--main justify-center">
         <div class="q-item__label">
           Development
@@ -8336,7 +8336,7 @@ exports[`Storyshots KAbout KAbout 1`] = `
       </div>
     </a> <a tabindex="0" href="https://fosstodon.org/@karrot" target="_blank" rel="noopener noreferrer" class="q-item q-item-type row no-wrap q-item--clickable q-link cursor-pointer q-focusable q-hoverable">
       <div tabindex="-1" class="q-focus-helper"></div>
-      <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-icon fab fa-fw fa-mastodon"> </i></div>
+      <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="fab fa-fw fa-mastodon q-icon"> </i></div>
       <div class="q-item__section column q-item__section--main justify-center">
         <div class="q-item__label">
           Mastodon
@@ -8344,7 +8344,7 @@ exports[`Storyshots KAbout KAbout 1`] = `
       </div>
     </a> <a tabindex="0" href="https://foodsaving.world" target="_blank" rel="noopener noreferrer" class="q-item q-item-type row no-wrap q-item--clickable q-link cursor-pointer q-focusable q-hoverable">
       <div tabindex="-1" class="q-focus-helper"></div>
-      <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-fw fa-globe"> </i></div>
+      <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="fas fa-fw fa-globe q-icon"> </i></div>
       <div class="q-item__section column q-item__section--main justify-center">
         <div class="q-item__label">
           Info
@@ -8355,7 +8355,7 @@ exports[`Storyshots KAbout KAbout 1`] = `
       </div>
     </a> <a tabindex="0" href="mailto:info@karrot.world" rel="noopener noreferrer" class="q-item q-item-type row no-wrap q-item--clickable q-link cursor-pointer q-focusable q-hoverable">
       <div tabindex="-1" class="q-focus-helper"></div>
-      <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-fw fa-envelope"> </i></div>
+      <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="fas fa-fw fa-envelope q-icon"> </i></div>
       <div class="q-item__section column q-item__section--main justify-center">
         <div class="q-item__label">
           info@karrot.world
@@ -8388,11 +8388,11 @@ exports[`Storyshots Latest Messages flag: closed 1`] = `
   </div>
   <div class="q-item__section column q-item__section--main justify-center">
     <div class="q-item__label row no-wrap justify-between items-baseline">
-      <div class="row no-wrap items-baseline ellipsis"><i aria-hidden="true" role="presentation" title="Application" class="q-mr-sm q-icon fas fa-fw fa-user-plus"> </i>
+      <div class="row no-wrap items-baseline ellipsis"><i aria-hidden="true" role="presentation" title="Application" class="q-mr-sm fas fa-fw fa-user-plus q-icon"> </i>
         <div class="ellipsis">
           Mira Bellenbaum
         </div>
-        <!----> <i aria-hidden="true" role="presentation" title="This conversation has been closed automatically." class="q-ml-xs q-icon text-grey fas fa-fw fa-lock" style="font-size:12px;"> </i>
+        <!----> <i aria-hidden="true" role="presentation" title="This conversation has been closed automatically." class="q-ml-xs fas fa-fw fa-lock q-icon text-grey" style="font-size:12px;"> </i>
       </div> <span><small><div title="Aug 11, 2017, 3:43 PM" class="q-pl-xs" style="white-space:nowrap;">
   4 months ago
 </div></small></span>
@@ -8422,10 +8422,10 @@ exports[`Storyshots Latest Messages flag: closed+muted 1`] = `
   </div>
   <div class="q-item__section column q-item__section--main justify-center">
     <div class="q-item__label row no-wrap justify-between items-baseline">
-      <div class="row no-wrap items-baseline ellipsis"><i aria-hidden="true" role="presentation" title="Application" class="q-mr-sm q-icon fas fa-fw fa-user-plus"> </i>
+      <div class="row no-wrap items-baseline ellipsis"><i aria-hidden="true" role="presentation" title="Application" class="q-mr-sm fas fa-fw fa-user-plus q-icon"> </i>
         <div class="ellipsis">
           Mira Bellenbaum
-        </div> <i aria-hidden="true" role="presentation" title="Notifications are disabled" class="q-ml-xs q-icon text-grey fas fa-fw fa-bell" style="font-size:12px;"> </i> <i aria-hidden="true" role="presentation" title="This conversation has been closed automatically." class="q-ml-xs q-icon text-grey fas fa-fw fa-lock" style="font-size:12px;"> </i>
+        </div> <i aria-hidden="true" role="presentation" title="Notifications are disabled" class="q-ml-xs fas fa-fw fa-bell q-icon text-grey" style="font-size:12px;"> </i> <i aria-hidden="true" role="presentation" title="This conversation has been closed automatically." class="q-ml-xs fas fa-fw fa-lock q-icon text-grey" style="font-size:12px;"> </i>
       </div> <span><small><div title="Aug 11, 2017, 3:43 PM" class="q-pl-xs" style="white-space:nowrap;">
   4 months ago
 </div></small></span>
@@ -8457,7 +8457,7 @@ exports[`Storyshots Latest Messages flag: muted 1`] = `
     <div class="q-item__label row no-wrap justify-between items-baseline">
       <div class="row no-wrap items-baseline ellipsis">
         Mira Bellenbaum
-        <i aria-hidden="true" role="presentation" title="Notifications are disabled" class="q-ml-xs q-icon text-grey fas fa-fw fa-bell" style="font-size:12px;"> </i>
+        <i aria-hidden="true" role="presentation" title="Notifications are disabled" class="q-ml-xs fas fa-fw fa-bell q-icon text-grey" style="font-size:12px;"> </i>
         <!---->
       </div> <span><small><div title="Aug 11, 2017, 3:43 PM" class="q-pl-xs" style="white-space:nowrap;">
   4 months ago
@@ -8521,7 +8521,7 @@ exports[`Storyshots Latest Messages flag: unread+muted 1`] = `
     <div class="q-item__label row no-wrap justify-between items-baseline">
       <div class="row no-wrap items-baseline ellipsis">
         Mira Bellenbaum
-        <i aria-hidden="true" role="presentation" title="Notifications are disabled" class="q-ml-xs q-icon text-grey fas fa-fw fa-bell" style="font-size:12px;"> </i>
+        <i aria-hidden="true" role="presentation" title="Notifications are disabled" class="q-ml-xs fas fa-fw fa-bell q-icon text-grey" style="font-size:12px;"> </i>
         <!---->
       </div> <span><small><div title="Aug 11, 2017, 3:43 PM" class="q-pl-xs" style="white-space:nowrap;">
   4 months ago
@@ -8548,7 +8548,7 @@ exports[`Storyshots Latest Messages type: activity chat 1`] = `
   <!---->
   <div class="q-item__section column q-item__section--main justify-center">
     <div class="q-item__label row no-wrap justify-between items-baseline">
-      <div class="row no-wrap items-baseline ellipsis"><i aria-hidden="true" role="presentation" class="q-mr-sm q-icon fas fa-fw fa-asterisk"> </i>
+      <div class="row no-wrap items-baseline ellipsis"><i aria-hidden="true" role="presentation" class="q-mr-sm fas fa-fw fa-asterisk q-icon"> </i>
         Saturday 8:00 AM
         <!---->
         <!---->
@@ -8584,7 +8584,7 @@ exports[`Storyshots Latest Messages type: application chat 1`] = `
   </div>
   <div class="q-item__section column q-item__section--main justify-center">
     <div class="q-item__label row no-wrap justify-between items-baseline">
-      <div class="row no-wrap items-baseline ellipsis"><i aria-hidden="true" role="presentation" title="Application" class="q-mr-sm q-icon fas fa-fw fa-user-plus"> </i>
+      <div class="row no-wrap items-baseline ellipsis"><i aria-hidden="true" role="presentation" title="Application" class="q-mr-sm fas fa-fw fa-user-plus q-icon"> </i>
         <div class="ellipsis">
           Mira Bellenbaum
         </div>
@@ -8615,7 +8615,7 @@ exports[`Storyshots Latest Messages type: group wall 1`] = `
   <!---->
   <div class="q-item__section column q-item__section--main justify-center">
     <div class="q-item__label row no-wrap justify-between items-baseline">
-      <div class="row no-wrap items-baseline ellipsis"><i aria-hidden="true" role="presentation" title="Wall" class="q-mr-sm q-icon fas fa-fw fa-bullhorn"> </i>
+      <div class="row no-wrap items-baseline ellipsis"><i aria-hidden="true" role="presentation" title="Wall" class="q-mr-sm fas fa-fw fa-bullhorn q-icon"> </i>
         <div class="ellipsis">
           05_testgroup
         </div>
@@ -8646,7 +8646,7 @@ exports[`Storyshots Latest Messages type: issue chat 1`] = `
   <!---->
   <div class="q-item__section column q-item__section--main justify-center">
     <div class="q-item__label row no-wrap justify-between items-baseline">
-      <div class="row no-wrap items-baseline ellipsis"><i aria-hidden="true" role="presentation" title="Issues" class="q-mr-sm q-icon fas fa-fw fa-vote-yea"> </i>
+      <div class="row no-wrap items-baseline ellipsis"><i aria-hidden="true" role="presentation" title="Issues" class="q-mr-sm fas fa-fw fa-vote-yea q-icon"> </i>
         <div class="ellipsis">
           User 195
         </div>
@@ -8681,7 +8681,7 @@ exports[`Storyshots Latest Messages type: my application chat 1`] = `
   </div>
   <div class="q-item__section column q-item__section--main justify-center">
     <div class="q-item__label row no-wrap justify-between items-baseline">
-      <div class="row no-wrap items-baseline ellipsis"><i aria-hidden="true" role="presentation" title="Application" class="q-mr-sm q-icon fas fa-fw fa-user-plus"> </i>
+      <div class="row no-wrap items-baseline ellipsis"><i aria-hidden="true" role="presentation" title="Application" class="q-mr-sm fas fa-fw fa-user-plus q-icon"> </i>
         <div class="ellipsis">
           05_testgroup
         </div>
@@ -8712,7 +8712,7 @@ exports[`Storyshots Latest Messages type: place wall 1`] = `
   <!---->
   <div class="q-item__section column q-item__section--main justify-center">
     <div class="q-item__label row no-wrap justify-between items-baseline">
-      <div class="row no-wrap items-baseline ellipsis"><i aria-hidden="true" role="presentation" title="Wall" class="q-mr-sm q-icon fas fa-fw fa-star"> </i>
+      <div class="row no-wrap items-baseline ellipsis"><i aria-hidden="true" role="presentation" title="Wall" class="q-mr-sm fas fa-fw fa-star q-icon"> </i>
         <div class="ellipsis">
           Place 21
         </div>
@@ -8774,7 +8774,7 @@ exports[`Storyshots Latest Messages type: thread 1`] = `
   <!---->
   <div class="q-item__section column q-item__section--main justify-center">
     <div class="q-item__label row no-wrap justify-between items-baseline">
-      <div class="row no-wrap items-baseline ellipsis"><i aria-hidden="true" role="presentation" class="q-mr-sm q-icon fas fa-fw fa-comments"> </i>
+      <div class="row no-wrap items-baseline ellipsis"><i aria-hidden="true" role="presentation" class="q-mr-sm fas fa-fw fa-comments q-icon"> </i>
         <div class="ellipsis">
           here is the message that started the thread
         </div>
@@ -8815,13 +8815,13 @@ exports[`Storyshots Layout KTopbar 1`] = `
     </div>
   </div>
   <div class="row no-wrap items-center">
-    <!----> <button tabindex="0" type="button" title="Search" class="q-btn q-btn-item non-selectable no-outline k-search-button q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon fas fa-fw fa-search"> </i></span></span></button> <button tabindex="0" type="button" title="Messages" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-icon fas fa-comments hasUnread"> </i> <div role="alert" class="q-badge flex inline items-center no-wrap q-badge--single-line bg-secondary q-badge--floating">
+    <!----> <button tabindex="0" type="button" title="Search" class="q-btn q-btn-item non-selectable no-outline k-search-button q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="fas fa-fw fa-search q-icon"> </i></span></span></button> <button tabindex="0" type="button" title="Messages" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="fas fa-comments q-icon hasUnread"> </i> <div role="alert" class="q-badge flex inline items-center no-wrap q-badge--single-line bg-secondary q-badge--floating">
     1
-  </div> <!----></span></span></button> <button tabindex="0" type="button" title="Notifications" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-icon fas fa-bell hasUnseen"> </i> <div role="alert" class="q-badge flex inline items-center no-wrap q-badge--single-line bg-secondary q-badge--floating">
+  </div> <!----></span></span></button> <button tabindex="0" type="button" title="Notifications" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="fas fa-bell q-icon hasUnseen"> </i> <div role="alert" class="q-badge flex inline items-center no-wrap q-badge--single-line bg-secondary q-badge--floating">
     1
-  </div> <!----></span></span></button> <a class="q-ml-xs"><button tabindex="0" type="button" title="Visit your profile" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--rectangle q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="presence-indicator q-icon text-secondary fas fa-circle"> </i>
+  </div> <!----></span></span></button> <a class="q-ml-xs"><button tabindex="0" type="button" title="Visit your profile" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--rectangle q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="presence-indicator fas fa-circle q-icon text-secondary"> </i>
           Current User
-          <i aria-hidden="true" role="presentation" class="q-icon fas fa-fw fa-user"> </i></span></span></button></a> <button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline k-more-options q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-icon fas fa-ellipsis-v"> </i> <!----></span></span></button>
+          <i aria-hidden="true" role="presentation" class="fas fa-fw fa-user q-icon"> </i></span></span></button></a> <button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline k-more-options q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="fas fa-ellipsis-v q-icon"> </i> <!----></span></span></button>
   </div>
 </div>
 `;
@@ -8830,7 +8830,7 @@ exports[`Storyshots Login empty 1`] = `
 <div>
   <form name="login">
     <div class="q-gutter-md"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--outlined q-field--float q-field--labeled">
-        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon text-grey-5 fas fa-envelope"> </i></div>
+        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-envelope q-icon text-grey-5"> </i></div>
         <div class="q-field__inner relative-position col self-stretch">
           <div tabindex="-1" class="q-field__control relative-position row no-wrap bg-white">
             <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" data-autofocus="true" aria-label="E-mail" autocorrect="off" autocapitalize="off" spellcheck="false" id="f_80808080-8080-4080-8080-808080808080" type="email" value="foo@foo.com" class="q-field__native q-placeholder">
@@ -8839,7 +8839,7 @@ exports[`Storyshots Login empty 1`] = `
           </div>
         </div>
       </label> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--outlined q-field--float q-field--labeled">
-        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon text-grey-5 fas fa-lock"> </i></div>
+        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-lock q-icon text-grey-5"> </i></div>
         <div class="q-field__inner relative-position col self-stretch">
           <div tabindex="-1" class="q-field__control relative-position row no-wrap bg-white">
             <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" aria-label="Password" autocorrect="off" autocapitalize="off" spellcheck="false" id="f_80808080-8080-4080-8080-808080808080" type="password" value="foofoo" class="q-field__native q-placeholder">
@@ -8867,17 +8867,17 @@ exports[`Storyshots Login error 1`] = `
 <div>
   <form name="login">
     <div class="q-gutter-md"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--outlined q-field--highlighted q-field--float q-field--labeled q-field--error shake">
-        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon text-grey-5 fas fa-envelope"> </i></div>
+        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-envelope q-icon text-grey-5"> </i></div>
         <div class="q-field__inner relative-position col self-stretch">
           <div tabindex="-1" class="q-field__control relative-position row no-wrap text-negative bg-white">
             <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" data-autofocus="true" aria-label="E-mail" autocorrect="off" autocapitalize="off" spellcheck="false" id="f_80808080-8080-4080-8080-808080808080" type="email" value="foo@foo.com" class="q-field__native q-placeholder">
               <div class="q-field__label no-pointer-events absolute ellipsis">E-mail</div>
             </div>
-            <div class="q-field__append q-field__marginal row no-wrap items-center q-anchor--skip"><i aria-hidden="true" role="presentation" class="q-icon text-negative notranslate material-icons">error</i></div>
+            <div class="q-field__append q-field__marginal row no-wrap items-center q-anchor--skip"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon text-negative">error</i></div>
           </div>
         </div>
       </label> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--outlined q-field--float q-field--labeled shake">
-        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon text-grey-5 fas fa-lock"> </i></div>
+        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-lock q-icon text-grey-5"> </i></div>
         <div class="q-field__inner relative-position col self-stretch">
           <div tabindex="-1" class="q-field__control relative-position row no-wrap bg-white">
             <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" aria-label="Password" autocorrect="off" autocapitalize="off" spellcheck="false" id="f_80808080-8080-4080-8080-808080808080" type="password" value="foofoo" class="q-field__native q-placeholder">
@@ -8907,7 +8907,7 @@ exports[`Storyshots Login pending 1`] = `
 <div>
   <form name="login">
     <div class="q-gutter-md"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--outlined q-field--float q-field--labeled">
-        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon text-grey-5 fas fa-envelope"> </i></div>
+        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-envelope q-icon text-grey-5"> </i></div>
         <div class="q-field__inner relative-position col self-stretch">
           <div tabindex="-1" class="q-field__control relative-position row no-wrap bg-white">
             <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" data-autofocus="true" aria-label="E-mail" autocorrect="off" autocapitalize="off" spellcheck="false" id="f_80808080-8080-4080-8080-808080808080" type="email" value="foo@foo.com" class="q-field__native q-placeholder">
@@ -8916,7 +8916,7 @@ exports[`Storyshots Login pending 1`] = `
           </div>
         </div>
       </label> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--outlined q-field--float q-field--labeled">
-        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon text-grey-5 fas fa-lock"> </i></div>
+        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-lock q-icon text-grey-5"> </i></div>
         <div class="q-field__inner relative-position col self-stretch">
           <div tabindex="-1" class="q-field__control relative-position row no-wrap bg-white">
             <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" aria-label="Password" autocorrect="off" autocapitalize="off" spellcheck="false" id="f_80808080-8080-4080-8080-808080808080" type="password" value="foofoo" class="q-field__native q-placeholder">
@@ -9016,24 +9016,24 @@ exports[`Storyshots Map UserMapPreview 1`] = `
 </div>
 `;
 
-exports[`Storyshots NotificationToggle muted 1`] = `<button tabindex="0" type="button" title="How do you want to receive notifications about new messages in this conversation/thread?" class="q-btn q-btn-item non-selectable no-outline q-btn--standard q-btn--round bg-grey-8 text-white q-btn--actionable q-focusable q-hoverable q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-icon fas fa-fw fa-bell" style="font-size:1.4em;"> </i> <!----></span></span></button>`;
+exports[`Storyshots NotificationToggle muted 1`] = `<button tabindex="0" type="button" title="How do you want to receive notifications about new messages in this conversation/thread?" class="q-btn q-btn-item non-selectable no-outline q-btn--standard q-btn--round bg-grey-8 text-white q-btn--actionable q-focusable q-hoverable q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="fas fa-fw fa-bell q-icon" style="font-size:1.4em;"> </i> <!----></span></span></button>`;
 
-exports[`Storyshots NotificationToggle subscribed - cannot unsubscribe 1`] = `<button tabindex="0" type="button" title="How do you want to receive notifications about new messages in this conversation/thread?" class="q-btn q-btn-item non-selectable no-outline q-btn--standard q-btn--round bg-secondary text-white q-btn--actionable q-focusable q-hoverable q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-icon fas fa-fw fa-envelope" style="font-size:1.4em;"> </i> <!----></span></span></button>`;
+exports[`Storyshots NotificationToggle subscribed - cannot unsubscribe 1`] = `<button tabindex="0" type="button" title="How do you want to receive notifications about new messages in this conversation/thread?" class="q-btn q-btn-item non-selectable no-outline q-btn--standard q-btn--round bg-secondary text-white q-btn--actionable q-focusable q-hoverable q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="fas fa-fw fa-envelope q-icon" style="font-size:1.4em;"> </i> <!----></span></span></button>`;
 
-exports[`Storyshots NotificationToggle subscribed - email not verified 1`] = `<button tabindex="0" type="button" title="How do you want to receive notifications about new messages in this conversation/thread?" class="q-btn q-btn-item non-selectable no-outline q-btn--standard q-btn--round bg-secondary text-white q-btn--actionable q-focusable q-hoverable q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-icon fas fa-fw fa-envelope" style="font-size:1.4em;"> </i> <!----></span></span></button>`;
+exports[`Storyshots NotificationToggle subscribed - email not verified 1`] = `<button tabindex="0" type="button" title="How do you want to receive notifications about new messages in this conversation/thread?" class="q-btn q-btn-item non-selectable no-outline q-btn--standard q-btn--round bg-secondary text-white q-btn--actionable q-focusable q-hoverable q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="fas fa-fw fa-envelope q-icon" style="font-size:1.4em;"> </i> <!----></span></span></button>`;
 
-exports[`Storyshots NotificationToggle subscribed - toolbar mode 1`] = `<button tabindex="0" type="button" title="How do you want to receive notifications about new messages in this conversation/thread?" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round text-white q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense bg-secondary"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-icon fas fa-fw fa-envelope" style="font-size:1.4em;"> </i> <!----></span></span></button>`;
+exports[`Storyshots NotificationToggle subscribed - toolbar mode 1`] = `<button tabindex="0" type="button" title="How do you want to receive notifications about new messages in this conversation/thread?" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round text-white q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense bg-secondary"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="fas fa-fw fa-envelope q-icon" style="font-size:1.4em;"> </i> <!----></span></span></button>`;
 
-exports[`Storyshots NotificationToggle subscribed 1`] = `<button tabindex="0" type="button" title="How do you want to receive notifications about new messages in this conversation/thread?" class="q-btn q-btn-item non-selectable no-outline q-btn--standard q-btn--round bg-secondary text-white q-btn--actionable q-focusable q-hoverable q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-icon fas fa-fw fa-envelope" style="font-size:1.4em;"> </i> <!----></span></span></button>`;
+exports[`Storyshots NotificationToggle subscribed 1`] = `<button tabindex="0" type="button" title="How do you want to receive notifications about new messages in this conversation/thread?" class="q-btn q-btn-item non-selectable no-outline q-btn--standard q-btn--round bg-secondary text-white q-btn--actionable q-focusable q-hoverable q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="fas fa-fw fa-envelope q-icon" style="font-size:1.4em;"> </i> <!----></span></span></button>`;
 
-exports[`Storyshots NotificationToggle unsubscribed 1`] = `<button tabindex="0" type="button" title="How do you want to receive notifications about new messages in this conversation/thread?" class="q-btn q-btn-item non-selectable no-outline q-btn--standard q-btn--round bg-grey-5 text-white q-btn--actionable q-focusable q-hoverable q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-icon fas fa-fw fa-eye-slash" style="font-size:1.4em;"> </i> <!----></span></span></button>`;
+exports[`Storyshots NotificationToggle unsubscribed 1`] = `<button tabindex="0" type="button" title="How do you want to receive notifications about new messages in this conversation/thread?" class="q-btn q-btn-item non-selectable no-outline q-btn--standard q-btn--round bg-grey-5 text-white q-btn--actionable q-focusable q-hoverable q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="fas fa-fw fa-eye-slash q-icon" style="font-size:1.4em;"> </i> <!----></span></span></button>`;
 
 exports[`Storyshots Notifications activity_disabled 1`] = `
 <a tabindex="0" href="#/" class="q-item q-item-type row no-wrap q-item--clickable q-link cursor-pointer q-focusable q-hoverable isUnread">
   <div tabindex="-1" class="q-focus-helper"></div>
   <!---->
   <div class="q-item__section column q-item__section--main justify-center">
-    <div class="q-item__label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" role="presentation" class="q-mx-xs vertical-baseline q-icon fas fa-times"> </i>
+    <div class="q-item__label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" role="presentation" class="q-mx-xs vertical-baseline fas fa-times q-icon"> </i>
       Pickup on Sunday, December 24, 12:00 PM was disabled
     </div>
     <div class="q-item__label q-item__label--caption text-caption">
@@ -9053,7 +9053,7 @@ exports[`Storyshots Notifications activity_enabled 1`] = `
   <div tabindex="-1" class="q-focus-helper"></div>
   <!---->
   <div class="q-item__section column q-item__section--main justify-center">
-    <div class="q-item__label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" role="presentation" class="q-mx-xs vertical-baseline q-icon fas fa-check"> </i>
+    <div class="q-item__label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" role="presentation" class="q-mx-xs vertical-baseline fas fa-check q-icon"> </i>
       Pickup on Sunday, December 24, 12:00 PM was enabled again
     </div>
     <div class="q-item__label q-item__label--caption text-caption">
@@ -9073,7 +9073,7 @@ exports[`Storyshots Notifications activity_moved 1`] = `
   <div tabindex="-1" class="q-focus-helper"></div>
   <!---->
   <div class="q-item__section column q-item__section--main justify-center">
-    <div class="q-item__label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" role="presentation" class="q-mx-xs vertical-baseline q-icon far fa-clock"> </i>
+    <div class="q-item__label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" role="presentation" class="q-mx-xs vertical-baseline far fa-clock q-icon"> </i>
       Pickup was moved to Sunday, December 24, 12:00 PM
     </div>
     <div class="q-item__label q-item__label--caption text-caption">
@@ -9093,7 +9093,7 @@ exports[`Storyshots Notifications activity_upcoming 1`] = `
   <div tabindex="-1" class="q-focus-helper"></div>
   <!---->
   <div class="q-item__section column q-item__section--main justify-center">
-    <div class="q-item__label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" role="presentation" class="q-mx-xs vertical-baseline q-icon fas fa-shopping-basket"> </i>
+    <div class="q-item__label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" role="presentation" class="q-mx-xs vertical-baseline fas fa-shopping-basket q-icon"> </i>
       Reminder: Pickup at 12:00 PM
     </div>
     <div class="q-item__label q-item__label--caption text-caption">
@@ -9113,7 +9113,7 @@ exports[`Storyshots Notifications application_accepted 1`] = `
   <div tabindex="-1" class="q-focus-helper"></div>
   <!---->
   <div class="q-item__section column q-item__section--main justify-center">
-    <div class="q-item__label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" role="presentation" class="q-mx-xs vertical-baseline q-icon fas fa-check"> </i>
+    <div class="q-item__label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" role="presentation" class="q-mx-xs vertical-baseline fas fa-check q-icon"> </i>
       Your application was accepted!
     </div>
     <div class="q-item__label q-item__label--caption text-caption">
@@ -9132,7 +9132,7 @@ exports[`Storyshots Notifications application_declined 1`] = `
   <div tabindex="-1" class="q-focus-helper"></div>
   <!---->
   <div class="q-item__section column q-item__section--main justify-center">
-    <div class="q-item__label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" role="presentation" class="q-mx-xs vertical-baseline q-icon fas fa-times"> </i>
+    <div class="q-item__label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" role="presentation" class="q-mx-xs vertical-baseline fas fa-times q-icon"> </i>
       Your application was declined
     </div>
     <div class="q-item__label q-item__label--caption text-caption">
@@ -9155,7 +9155,7 @@ exports[`Storyshots Notifications conflict_resolution_continued 1`] = `
       </a></div>
   </div>
   <div class="q-item__section column q-item__section--main justify-center">
-    <div class="q-item__label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" role="presentation" class="q-mx-xs vertical-baseline q-icon far fa-frown-open"> </i>
+    <div class="q-item__label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" role="presentation" class="q-mx-xs vertical-baseline far fa-frown-open q-icon"> </i>
       The conflict resolution process with User 134 continues
     </div>
     <div class="q-item__label q-item__label--caption text-caption">
@@ -9174,7 +9174,7 @@ exports[`Storyshots Notifications conflict_resolution_continued_about_you 1`] = 
   <div tabindex="-1" class="q-focus-helper"></div>
   <!---->
   <div class="q-item__section column q-item__section--main justify-center">
-    <div class="q-item__label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" role="presentation" class="q-mx-xs vertical-baseline q-icon far fa-frown-open"> </i>
+    <div class="q-item__label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" role="presentation" class="q-mx-xs vertical-baseline far fa-frown-open q-icon"> </i>
       The conflict resolution process with you continues
     </div>
     <div class="q-item__label q-item__label--caption text-caption">
@@ -9197,7 +9197,7 @@ exports[`Storyshots Notifications conflict_resolution_created 1`] = `
       </a></div>
   </div>
   <div class="q-item__section column q-item__section--main justify-center">
-    <div class="q-item__label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" role="presentation" class="q-mx-xs vertical-baseline q-icon far fa-frown-open"> </i>
+    <div class="q-item__label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" role="presentation" class="q-mx-xs vertical-baseline far fa-frown-open q-icon"> </i>
       Join the discussion about a conflict with User 129
     </div>
     <div class="q-item__label q-item__label--caption text-caption">
@@ -9216,7 +9216,7 @@ exports[`Storyshots Notifications conflict_resolution_created_about_you 1`] = `
   <div tabindex="-1" class="q-focus-helper"></div>
   <!---->
   <div class="q-item__section column q-item__section--main justify-center">
-    <div class="q-item__label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" role="presentation" class="q-mx-xs vertical-baseline q-icon far fa-frown-open"> </i>
+    <div class="q-item__label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" role="presentation" class="q-mx-xs vertical-baseline far fa-frown-open q-icon"> </i>
       A conflict resolution process was started with you
     </div>
     <div class="q-item__label q-item__label--caption text-caption">
@@ -9239,7 +9239,7 @@ exports[`Storyshots Notifications conflict_resolution_decided 1`] = `
       </a></div>
   </div>
   <div class="q-item__section column q-item__section--main justify-center">
-    <div class="q-item__label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" role="presentation" class="q-mx-xs vertical-baseline q-icon far fa-frown-open"> </i>
+    <div class="q-item__label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" role="presentation" class="q-mx-xs vertical-baseline far fa-frown-open q-icon"> </i>
       The conflict resolution process with User 139 was decided
     </div>
     <div class="q-item__label q-item__label--caption text-caption">
@@ -9258,7 +9258,7 @@ exports[`Storyshots Notifications conflict_resolution_decided_about_you 1`] = `
   <div tabindex="-1" class="q-focus-helper"></div>
   <!---->
   <div class="q-item__section column q-item__section--main justify-center">
-    <div class="q-item__label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" role="presentation" class="q-mx-xs vertical-baseline q-icon far fa-frown-open"> </i>
+    <div class="q-item__label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" role="presentation" class="q-mx-xs vertical-baseline far fa-frown-open q-icon"> </i>
       The conflict resolution process with you was decided
     </div>
     <div class="q-item__label q-item__label--caption text-caption">
@@ -9277,7 +9277,7 @@ exports[`Storyshots Notifications conflict_resolution_you_were_removed 1`] = `
   <div tabindex="-1" class="q-focus-helper"></div>
   <!---->
   <div class="q-item__section column q-item__section--main justify-center">
-    <div class="q-item__label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" role="presentation" class="q-mx-xs vertical-baseline q-icon fas fa-times"> </i>
+    <div class="q-item__label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" role="presentation" class="q-mx-xs vertical-baseline fas fa-times q-icon"> </i>
       You were removed from the group
     </div>
     <div class="q-item__label q-item__label--caption text-caption">
@@ -9296,7 +9296,7 @@ exports[`Storyshots Notifications feedback_possible 1`] = `
   <div tabindex="-1" class="q-focus-helper"></div>
   <!---->
   <div class="q-item__section column q-item__section--main justify-center">
-    <div class="q-item__label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" role="presentation" class="q-mx-xs vertical-baseline q-icon fas fa-balance-scale"> </i>
+    <div class="q-item__label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" role="presentation" class="q-mx-xs vertical-baseline fas fa-balance-scale q-icon"> </i>
       You can give feedback - Pickup on Sunday 12:00 PM
     </div>
     <div class="q-item__label q-item__label--caption text-caption">
@@ -9320,7 +9320,7 @@ exports[`Storyshots Notifications invitation_accepted 1`] = `
       </a></div>
   </div>
   <div class="q-item__section column q-item__section--main justify-center">
-    <div class="q-item__label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" role="presentation" class="q-mx-xs vertical-baseline q-icon fas fa-user-plus"> </i>
+    <div class="q-item__label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" role="presentation" class="q-mx-xs vertical-baseline fas fa-user-plus q-icon"> </i>
       User 126 accepted your invitation
     </div>
     <div class="q-item__label q-item__label--caption text-caption">
@@ -9343,7 +9343,7 @@ exports[`Storyshots Notifications new_applicant 1`] = `
       </a></div>
   </div>
   <div class="q-item__section column q-item__section--main justify-center">
-    <div class="q-item__label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" role="presentation" class="q-mx-xs vertical-baseline q-icon fas fa-address-card"> </i>
+    <div class="q-item__label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" role="presentation" class="q-mx-xs vertical-baseline fas fa-address-card q-icon"> </i>
       User 121 applied to join your group
     </div>
     <div class="q-item__label q-item__label--caption text-caption">
@@ -9366,7 +9366,7 @@ exports[`Storyshots Notifications new_member 1`] = `
       </a></div>
   </div>
   <div class="q-item__section column q-item__section--main justify-center">
-    <div class="q-item__label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" role="presentation" class="q-mx-xs vertical-baseline q-icon fas fa-user-plus"> </i>
+    <div class="q-item__label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" role="presentation" class="q-mx-xs vertical-baseline fas fa-user-plus q-icon"> </i>
       User 125 joined your group
     </div>
     <div class="q-item__label q-item__label--caption text-caption">
@@ -9385,7 +9385,7 @@ exports[`Storyshots Notifications new_place 1`] = `
   <div tabindex="-1" class="q-focus-helper"></div>
   <!---->
   <div class="q-item__section column q-item__section--main justify-center">
-    <div class="q-item__label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" role="presentation" class="q-mx-xs vertical-baseline q-icon fas fa-circle"> </i>
+    <div class="q-item__label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" role="presentation" class="q-mx-xs vertical-baseline fas fa-circle q-icon"> </i>
       Place 2 has been created
     </div>
     <div class="q-item__label q-item__label--caption text-caption">
@@ -9408,7 +9408,7 @@ exports[`Storyshots Notifications user_became_editor 1`] = `
       </a></div>
   </div>
   <div class="q-item__section column q-item__section--main justify-center">
-    <div class="q-item__label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" role="presentation" class="q-mx-xs vertical-baseline q-icon fas fa-angle-double-up"> </i>
+    <div class="q-item__label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" role="presentation" class="q-mx-xs vertical-baseline fas fa-angle-double-up q-icon"> </i>
       User 119 gained editing permissions
     </div>
     <div class="q-item__label q-item__label--caption text-caption">
@@ -9427,7 +9427,7 @@ exports[`Storyshots Notifications voting_ends_soon 1`] = `
   <div tabindex="-1" class="q-focus-helper"></div>
   <!---->
   <div class="q-item__section column q-item__section--main justify-center">
-    <div class="q-item__label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" role="presentation" class="q-mx-xs vertical-baseline q-icon far fa-clock"> </i>
+    <div class="q-item__label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" role="presentation" class="q-mx-xs vertical-baseline far fa-clock q-icon"> </i>
       Voting ends soon, don't forget to participate!
     </div>
     <div class="q-item__label q-item__label--caption text-caption">
@@ -9446,7 +9446,7 @@ exports[`Storyshots Notifications you_became_editor 1`] = `
   <div tabindex="-1" class="q-focus-helper"></div>
   <!---->
   <div class="q-item__section column q-item__section--main justify-center">
-    <div class="q-item__label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" role="presentation" class="q-mx-xs vertical-baseline q-icon fas fa-angle-double-up"> </i>
+    <div class="q-item__label" style="overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;"><i aria-hidden="true" role="presentation" class="q-mx-xs vertical-baseline fas fa-angle-double-up q-icon"> </i>
       You gained editing permissions
     </div>
     <div class="q-item__label q-item__label--caption text-caption">
@@ -9467,7 +9467,7 @@ exports[`Storyshots Password Reset empty 1`] = `
       <p>
         Enter your Email address and we will send you a link to set a new password (if you have an account registered).
       </p> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--outlined q-field--labeled">
-        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon text-grey-5 fas fa-envelope"> </i></div>
+        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-envelope q-icon text-grey-5"> </i></div>
         <div class="q-field__inner relative-position col self-stretch">
           <div tabindex="-1" class="q-field__control relative-position row no-wrap bg-white">
             <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" data-autofocus="true" aria-label="Email address" autocorrect="off" autocapitalize="off" spellcheck="false" id="f_80808080-8080-4080-8080-808080808080" type="email" value="" class="q-field__native q-placeholder">
@@ -9497,13 +9497,13 @@ exports[`Storyshots Password Reset error 1`] = `
       <p>
         Enter your Email address and we will send you a link to set a new password (if you have an account registered).
       </p> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--outlined q-field--highlighted q-field--labeled q-field--error">
-        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon text-grey-5 fas fa-envelope"> </i></div>
+        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-envelope q-icon text-grey-5"> </i></div>
         <div class="q-field__inner relative-position col self-stretch">
           <div tabindex="-1" class="q-field__control relative-position row no-wrap text-negative bg-white">
             <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" data-autofocus="true" aria-label="Email address" autocorrect="off" autocapitalize="off" spellcheck="false" id="f_80808080-8080-4080-8080-808080808080" type="email" value="" class="q-field__native q-placeholder">
               <div class="q-field__label no-pointer-events absolute ellipsis">Email address</div>
             </div>
-            <div class="q-field__append q-field__marginal row no-wrap items-center q-anchor--skip"><i aria-hidden="true" role="presentation" class="q-icon text-negative notranslate material-icons">error</i></div>
+            <div class="q-field__append q-field__marginal row no-wrap items-center q-anchor--skip"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon text-negative">error</i></div>
           </div>
         </div>
       </label>
@@ -9530,7 +9530,7 @@ exports[`Storyshots Password Reset pending 1`] = `
       <p>
         Enter your Email address and we will send you a link to set a new password (if you have an account registered).
       </p> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--outlined q-field--labeled">
-        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon text-grey-5 fas fa-envelope"> </i></div>
+        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-envelope q-icon text-grey-5"> </i></div>
         <div class="q-field__inner relative-position col self-stretch">
           <div tabindex="-1" class="q-field__control relative-position row no-wrap bg-white">
             <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" data-autofocus="true" aria-label="Email address" autocorrect="off" autocapitalize="off" spellcheck="false" id="f_80808080-8080-4080-8080-808080808080" type="email" value="" class="q-field__native q-placeholder">
@@ -9560,7 +9560,7 @@ exports[`Storyshots Password Reset success 1`] = `
       <p>
         Enter your Email address and we will send you a link to set a new password (if you have an account registered).
       </p> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--outlined q-field--labeled">
-        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon text-grey-5 fas fa-envelope"> </i></div>
+        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-envelope q-icon text-grey-5"> </i></div>
         <div class="q-field__inner relative-position col self-stretch">
           <div tabindex="-1" class="q-field__control relative-position row no-wrap bg-white">
             <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" data-autofocus="true" aria-label="Email address" autocorrect="off" autocapitalize="off" spellcheck="false" id="f_80808080-8080-4080-8080-808080808080" type="email" value="" class="q-field__native q-placeholder">
@@ -9588,13 +9588,13 @@ exports[`Storyshots Places PlaceEdit (with server error) 1`] = `
   <div class="no-shadow grey-border q-card" style="max-width:700px;">
     <div class="edit-box">
       <form><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-mb-lg q-input q-field--outlined q-field--highlighted q-field--float q-field--labeled q-field--with-bottom q-field--error">
-          <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-star"> </i></div>
+          <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-star q-icon"> </i></div>
           <div class="q-field__inner relative-position col self-stretch">
             <div tabindex="-1" class="q-field__control relative-position row no-wrap text-negative">
               <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" data-autofocus="true" aria-label="Name" autocomplete="off" id="f_80808080-8080-4080-8080-808080808080" type="text" value="Place 3" class="q-field__native q-placeholder">
                 <div class="q-field__label no-pointer-events absolute ellipsis">Name</div>
               </div>
-              <div class="q-field__append q-field__marginal row no-wrap items-center q-anchor--skip"><i aria-hidden="true" role="presentation" class="q-icon text-negative notranslate material-icons">error</i></div>
+              <div class="q-field__append q-field__marginal row no-wrap items-center q-anchor--skip"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon text-negative">error</i></div>
             </div>
             <div class="q-field__bottom row items-start q-field__bottom--animated">
               <transition-stub name="q-transition--field-message">
@@ -9605,21 +9605,21 @@ exports[`Storyshots Places PlaceEdit (with server error) 1`] = `
             </div>
           </div>
         </label> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-mb-lg q-select q-field--auto-height q-select--without-input q-select--without-chips q-select--single q-field--outlined q-field--float q-field--labeled q-field--with-bottom">
-          <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-handshake"> </i></div>
+          <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-handshake q-icon"> </i></div>
           <div class="q-field__inner relative-position col self-stretch">
             <div tabindex="-1" class="q-field__control relative-position row no-wrap">
               <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip">
                 <div class="q-field__native row items-center">
-                  <div class="row"><i aria-hidden="true" role="presentation" class="on-left q-ml-xs q-icon text-positive fas fa-circle" style="font-size:1.1em;"> </i>
+                  <div class="row"><i aria-hidden="true" role="presentation" class="on-left q-ml-xs fas fa-circle q-icon text-positive" style="font-size:1.1em;"> </i>
                     <div>
                       Co-operating
                     </div>
                   </div>
-                  <div id="f_80808080-8080-4080-8080-808080808080" tabindex="0" role="combobox" aria-multiselectable="false" aria-expanded="false" aria-owns="f_80808080-8080-4080-8080-808080808080_lb" aria-activedescendant="f_80808080-8080-4080-8080-808080808080_-1" class="q-select__focus-target"></div>
+                  <div id="f_80808080-8080-4080-8080-808080808080" tabindex="0" role="combobox" aria-multiselectable="false" aria-expanded="false" aria-owns="f_80808080-8080-4080-8080-808080808080_lb" aria-activedescendant="f_80808080-8080-4080-8080-808080808080_-1" class="no-outline"></div>
                 </div>
                 <div class="q-field__label no-pointer-events absolute ellipsis">Status</div>
               </div>
-              <div class="q-field__append q-field__marginal row no-wrap items-center q-anchor--skip"><i aria-hidden="true" role="presentation" class="q-select__dropdown-icon q-icon notranslate material-icons">arrow_drop_down</i></div>
+              <div class="q-field__append q-field__marginal row no-wrap items-center q-anchor--skip"><i aria-hidden="true" role="presentation" class="q-select__dropdown-icon notranslate material-icons q-icon">arrow_drop_down</i></div>
               <!---->
             </div>
             <div class="q-field__bottom row items-start q-field__bottom--animated">
@@ -9631,7 +9631,7 @@ exports[`Storyshots Places PlaceEdit (with server error) 1`] = `
         </label>
         <div class="mentionable q-mb-lg" style="position:relative;">
           <div class="relative-position q-mb-sm"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-textarea q-textarea--autogrow q-field--outlined q-field--labeled q-field--with-bottom">
-              <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-question"> </i></div>
+              <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-question q-icon"> </i></div>
               <div class="q-field__inner relative-position col self-stretch">
                 <div tabindex="-1" class="q-field__control relative-position row no-wrap">
                   <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><textarea tabindex="0" rows="1" aria-label="Description" id="f_80808080-8080-4080-8080-808080808080" type="textarea" class="q-field__native q-placeholder" style="min-height:100px;"></textarea>
@@ -9666,16 +9666,16 @@ exports[`Storyshots Places PlaceEdit (with server error) 1`] = `
             </div>
           </div>
         </div> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-mb-lg q-select q-field--auto-height q-select--without-input q-select--without-chips q-select--single q-field--outlined q-field--labeled q-field--with-bottom">
-          <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-eye"> </i></div>
+          <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-eye q-icon"> </i></div>
           <div class="q-field__inner relative-position col self-stretch">
             <div tabindex="-1" class="q-field__control relative-position row no-wrap">
               <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip">
                 <div class="q-field__native row items-center"><span></span>
-                  <div id="f_80808080-8080-4080-8080-808080808080" tabindex="0" role="combobox" aria-multiselectable="false" aria-expanded="false" aria-owns="f_80808080-8080-4080-8080-808080808080_lb" aria-activedescendant="f_80808080-8080-4080-8080-808080808080_-1" class="q-select__focus-target"></div>
+                  <div id="f_80808080-8080-4080-8080-808080808080" tabindex="0" role="combobox" aria-multiselectable="false" aria-expanded="false" aria-owns="f_80808080-8080-4080-8080-808080808080_lb" aria-activedescendant="f_80808080-8080-4080-8080-808080808080_-1" class="no-outline"></div>
                 </div>
                 <div class="q-field__label no-pointer-events absolute ellipsis">Default View</div>
               </div>
-              <div class="q-field__append q-field__marginal row no-wrap items-center q-anchor--skip"><i aria-hidden="true" role="presentation" class="q-select__dropdown-icon q-icon notranslate material-icons">arrow_drop_down</i></div>
+              <div class="q-field__append q-field__marginal row no-wrap items-center q-anchor--skip"><i aria-hidden="true" role="presentation" class="q-select__dropdown-icon notranslate material-icons q-icon">arrow_drop_down</i></div>
               <!---->
             </div>
             <div class="q-field__bottom row items-start q-field__bottom--animated">
@@ -9688,11 +9688,11 @@ exports[`Storyshots Places PlaceEdit (with server error) 1`] = `
           </div>
         </label>
         <div class="q-mb-lg"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-select q-field--auto-height q-select--with-input q-select--without-chips q-select--single q-field--outlined q-field--labeled q-field--with-bottom">
-            <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-map-marker"> </i></div>
+            <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-map-marker q-icon"> </i></div>
             <div class="q-field__inner relative-position col self-stretch">
               <div tabindex="-1" class="q-field__control relative-position row no-wrap">
                 <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip">
-                  <div class="q-field__native row items-center"><input type="search" role="combobox" aria-multiselectable="false" aria-expanded="false" aria-owns="f_80808080-8080-4080-8080-808080808080_lb" aria-activedescendant="f_80808080-8080-4080-8080-808080808080_-1" placeholder="Search" id="f_80808080-8080-4080-8080-808080808080" tabindex="0" value="" class="q-field__input q-placeholder col q-field__input--padding"></div>
+                  <div placeholder="Search" class="q-field__native row items-center"><input type="search" placeholder="Search" id="f_80808080-8080-4080-8080-808080808080" tabindex="0" role="combobox" aria-multiselectable="false" aria-expanded="false" aria-owns="f_80808080-8080-4080-8080-808080808080_lb" aria-activedescendant="f_80808080-8080-4080-8080-808080808080_-1" value="" class="q-field__input q-placeholder col q-field__input--padding"></div>
                   <div class="q-field__label no-pointer-events absolute ellipsis">Address</div>
                 </div>
                 <div class="q-field__append q-field__marginal row no-wrap items-center"></div>
@@ -9709,7 +9709,7 @@ exports[`Storyshots Places PlaceEdit (with server error) 1`] = `
           </div>
         </div>
         <div><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-field--borderless q-field--float q-field--auto-height">
-            <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-calendar-alt"> </i></div>
+            <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-calendar-alt q-icon"> </i></div>
             <div class="q-field__inner relative-position col self-stretch">
               <div tabindex="-1" class="q-field__control relative-position row no-wrap">
                 <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip">
@@ -9768,7 +9768,7 @@ exports[`Storyshots Places PlaceEdit 1`] = `
   <div class="no-shadow grey-border q-card" style="max-width:700px;">
     <div class="edit-box">
       <form><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-mb-lg q-input q-field--outlined q-field--float q-field--labeled q-field--with-bottom">
-          <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-star"> </i></div>
+          <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-star q-icon"> </i></div>
           <div class="q-field__inner relative-position col self-stretch">
             <div tabindex="-1" class="q-field__control relative-position row no-wrap">
               <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" data-autofocus="true" aria-label="Name" autocomplete="off" id="f_80808080-8080-4080-8080-808080808080" type="text" value="Place 3" class="q-field__native q-placeholder">
@@ -9782,21 +9782,21 @@ exports[`Storyshots Places PlaceEdit 1`] = `
             </div>
           </div>
         </label> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-mb-lg q-select q-field--auto-height q-select--without-input q-select--without-chips q-select--single q-field--outlined q-field--float q-field--labeled q-field--with-bottom">
-          <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-handshake"> </i></div>
+          <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-handshake q-icon"> </i></div>
           <div class="q-field__inner relative-position col self-stretch">
             <div tabindex="-1" class="q-field__control relative-position row no-wrap">
               <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip">
                 <div class="q-field__native row items-center">
-                  <div class="row"><i aria-hidden="true" role="presentation" class="on-left q-ml-xs q-icon text-positive fas fa-circle" style="font-size:1.1em;"> </i>
+                  <div class="row"><i aria-hidden="true" role="presentation" class="on-left q-ml-xs fas fa-circle q-icon text-positive" style="font-size:1.1em;"> </i>
                     <div>
                       Co-operating
                     </div>
                   </div>
-                  <div id="f_80808080-8080-4080-8080-808080808080" tabindex="0" role="combobox" aria-multiselectable="false" aria-expanded="false" aria-owns="f_80808080-8080-4080-8080-808080808080_lb" aria-activedescendant="f_80808080-8080-4080-8080-808080808080_-1" class="q-select__focus-target"></div>
+                  <div id="f_80808080-8080-4080-8080-808080808080" tabindex="0" role="combobox" aria-multiselectable="false" aria-expanded="false" aria-owns="f_80808080-8080-4080-8080-808080808080_lb" aria-activedescendant="f_80808080-8080-4080-8080-808080808080_-1" class="no-outline"></div>
                 </div>
                 <div class="q-field__label no-pointer-events absolute ellipsis">Status</div>
               </div>
-              <div class="q-field__append q-field__marginal row no-wrap items-center q-anchor--skip"><i aria-hidden="true" role="presentation" class="q-select__dropdown-icon q-icon notranslate material-icons">arrow_drop_down</i></div>
+              <div class="q-field__append q-field__marginal row no-wrap items-center q-anchor--skip"><i aria-hidden="true" role="presentation" class="q-select__dropdown-icon notranslate material-icons q-icon">arrow_drop_down</i></div>
               <!---->
             </div>
             <div class="q-field__bottom row items-start q-field__bottom--animated">
@@ -9808,7 +9808,7 @@ exports[`Storyshots Places PlaceEdit 1`] = `
         </label>
         <div class="mentionable q-mb-lg" style="position:relative;">
           <div class="relative-position q-mb-sm"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-textarea q-textarea--autogrow q-field--outlined q-field--labeled q-field--with-bottom">
-              <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-question"> </i></div>
+              <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-question q-icon"> </i></div>
               <div class="q-field__inner relative-position col self-stretch">
                 <div tabindex="-1" class="q-field__control relative-position row no-wrap">
                   <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><textarea tabindex="0" rows="1" aria-label="Description" id="f_80808080-8080-4080-8080-808080808080" type="textarea" class="q-field__native q-placeholder" style="min-height:100px;"></textarea>
@@ -9843,16 +9843,16 @@ exports[`Storyshots Places PlaceEdit 1`] = `
             </div>
           </div>
         </div> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-mb-lg q-select q-field--auto-height q-select--without-input q-select--without-chips q-select--single q-field--outlined q-field--labeled q-field--with-bottom">
-          <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-eye"> </i></div>
+          <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-eye q-icon"> </i></div>
           <div class="q-field__inner relative-position col self-stretch">
             <div tabindex="-1" class="q-field__control relative-position row no-wrap">
               <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip">
                 <div class="q-field__native row items-center"><span></span>
-                  <div id="f_80808080-8080-4080-8080-808080808080" tabindex="0" role="combobox" aria-multiselectable="false" aria-expanded="false" aria-owns="f_80808080-8080-4080-8080-808080808080_lb" aria-activedescendant="f_80808080-8080-4080-8080-808080808080_-1" class="q-select__focus-target"></div>
+                  <div id="f_80808080-8080-4080-8080-808080808080" tabindex="0" role="combobox" aria-multiselectable="false" aria-expanded="false" aria-owns="f_80808080-8080-4080-8080-808080808080_lb" aria-activedescendant="f_80808080-8080-4080-8080-808080808080_-1" class="no-outline"></div>
                 </div>
                 <div class="q-field__label no-pointer-events absolute ellipsis">Default View</div>
               </div>
-              <div class="q-field__append q-field__marginal row no-wrap items-center q-anchor--skip"><i aria-hidden="true" role="presentation" class="q-select__dropdown-icon q-icon notranslate material-icons">arrow_drop_down</i></div>
+              <div class="q-field__append q-field__marginal row no-wrap items-center q-anchor--skip"><i aria-hidden="true" role="presentation" class="q-select__dropdown-icon notranslate material-icons q-icon">arrow_drop_down</i></div>
               <!---->
             </div>
             <div class="q-field__bottom row items-start q-field__bottom--animated">
@@ -9865,11 +9865,11 @@ exports[`Storyshots Places PlaceEdit 1`] = `
           </div>
         </label>
         <div class="q-mb-lg"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-select q-field--auto-height q-select--with-input q-select--without-chips q-select--single q-field--outlined q-field--labeled q-field--with-bottom">
-            <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-map-marker"> </i></div>
+            <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-map-marker q-icon"> </i></div>
             <div class="q-field__inner relative-position col self-stretch">
               <div tabindex="-1" class="q-field__control relative-position row no-wrap">
                 <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip">
-                  <div class="q-field__native row items-center"><input type="search" role="combobox" aria-multiselectable="false" aria-expanded="false" aria-owns="f_80808080-8080-4080-8080-808080808080_lb" aria-activedescendant="f_80808080-8080-4080-8080-808080808080_-1" placeholder="Search" id="f_80808080-8080-4080-8080-808080808080" tabindex="0" value="" class="q-field__input q-placeholder col q-field__input--padding"></div>
+                  <div placeholder="Search" class="q-field__native row items-center"><input type="search" placeholder="Search" id="f_80808080-8080-4080-8080-808080808080" tabindex="0" role="combobox" aria-multiselectable="false" aria-expanded="false" aria-owns="f_80808080-8080-4080-8080-808080808080_lb" aria-activedescendant="f_80808080-8080-4080-8080-808080808080_-1" value="" class="q-field__input q-placeholder col q-field__input--padding"></div>
                   <div class="q-field__label no-pointer-events absolute ellipsis">Address</div>
                 </div>
                 <div class="q-field__append q-field__marginal row no-wrap items-center"></div>
@@ -9886,7 +9886,7 @@ exports[`Storyshots Places PlaceEdit 1`] = `
           </div>
         </div>
         <div><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-field--borderless q-field--float q-field--auto-height">
-            <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-calendar-alt"> </i></div>
+            <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-calendar-alt q-icon"> </i></div>
             <div class="q-field__inner relative-position col self-stretch">
               <div tabindex="-1" class="q-field__control relative-position row no-wrap">
                 <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip">
@@ -9960,12 +9960,12 @@ exports[`Storyshots Places PlaceHeader 1`] = `
     <div seed="3" type="banner"></div>
   </div>
   <div class="toolbar row justify-between bg-white q-pb-xs">
-    <div title="5 people have marked this place as favourite" class="q-chip row inline no-wrap items-center self-center q-ml-sm cursor-pointer bg-secondary text-white q-chip--colored q-chip--square" style="z-index:0;"><i aria-hidden="true" role="presentation" class="q-chip__icon q-chip__icon--left q-icon fas fa-star"> </i>
+    <div title="5 people have marked this place as favourite" class="q-chip row inline no-wrap items-center self-center q-ml-sm cursor-pointer bg-secondary text-white q-chip--colored q-chip--square" style="z-index:0;"><i aria-hidden="true" role="presentation" class="q-chip__icon q-chip__icon--left fas fa-star q-icon"> </i>
       <div class="q-chip__content col row no-wrap items-center q-anchor--skip"><strong>5</strong>
         <!---->
       </div>
     </div>
-    <div><button tabindex="0" type="button" title="Do you want to mark this place as your favourite?" class="q-btn q-btn-item non-selectable no-outline q-btn--standard q-btn--round bg-white text-secondary q-btn--actionable q-focusable q-hoverable q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon fas fa-fw fa-star"> </i><!----></span></span></button> <span target="_blank" rel="noopener nofollow noreferrer"><button tabindex="-1" type="button" disabled="disabled" aria-disabled="true" title="Show directions" class="q-btn q-btn-item non-selectable no-outline q-btn--standard q-btn--round bg-grey text-white disabled q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon notranslate material-icons">directions</i></span></span></button></span>
+    <div><button tabindex="0" type="button" title="Do you want to mark this place as your favourite?" class="q-btn q-btn-item non-selectable no-outline q-btn--standard q-btn--round bg-white text-secondary q-btn--actionable q-focusable q-hoverable q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="fas fa-fw fa-star q-icon"> </i><!----></span></span></button> <span target="_blank" rel="noopener nofollow noreferrer"><button tabindex="-1" type="button" disabled="disabled" aria-disabled="true" title="Show directions" class="q-btn q-btn-item non-selectable no-outline q-btn--standard q-btn--round bg-grey text-white disabled q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="notranslate material-icons q-icon">directions</i></span></span></button></span>
       <!---->
     </div>
   </div>
@@ -9982,11 +9982,11 @@ exports[`Storyshots Places PlaceHeader 1`] = `
 exports[`Storyshots Places PlaceList 1`] = `
 <div class="q-list"><a tabindex="0" href="#/" class="q-item q-item-type row no-wrap q-item--clickable q-link cursor-pointer q-focusable q-hoverable q-item--dense router-link-active">
     <div tabindex="-1" class="q-focus-helper"></div>
-    <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" title="Co-operating" class="q-icon text-positive fas fa-circle" style="font-size:1.1em;"> </i></div>
+    <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" title="Co-operating" class="fas fa-circle q-icon text-positive" style="font-size:1.1em;"> </i></div>
     <div class="q-item__section column q-item__section--main justify-center">
       <div class="q-item__label items-baseline">
         Place 3
-        <i aria-hidden="true" role="presentation" class="vertical-baseline q-ml-xs q-icon text-secondary fas fa-fw fa-star"> </i>
+        <i aria-hidden="true" role="presentation" class="vertical-baseline q-ml-xs fas fa-fw fa-star q-icon text-secondary"> </i>
       </div>
     </div>
     <div class="q-item__section column q-item__section--side justify-center">
@@ -9996,7 +9996,7 @@ exports[`Storyshots Places PlaceList 1`] = `
     </div>
   </a><a tabindex="0" href="#/" class="q-item q-item-type row no-wrap q-item--clickable q-link cursor-pointer q-focusable q-hoverable q-item--dense">
     <div tabindex="-1" class="q-focus-helper"></div>
-    <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" title="Co-operating" class="q-icon text-positive fas fa-circle" style="font-size:1.1em;"> </i></div>
+    <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" title="Co-operating" class="fas fa-circle q-icon text-positive" style="font-size:1.1em;"> </i></div>
     <div class="q-item__section column q-item__section--main justify-center">
       <div class="q-item__label items-baseline">
         Place 4
@@ -10006,7 +10006,7 @@ exports[`Storyshots Places PlaceList 1`] = `
     <!---->
   </a><a tabindex="0" href="#/" class="q-item q-item-type row no-wrap q-item--clickable q-link cursor-pointer q-focusable q-hoverable q-item--dense">
     <div tabindex="-1" class="q-focus-helper"></div>
-    <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" title="Co-operating" class="q-icon text-positive fas fa-circle" style="font-size:1.1em;"> </i></div>
+    <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" title="Co-operating" class="fas fa-circle q-icon text-positive" style="font-size:1.1em;"> </i></div>
     <div class="q-item__section column q-item__section--main justify-center">
       <div class="q-item__label items-baseline">
         Place 5
@@ -10016,7 +10016,7 @@ exports[`Storyshots Places PlaceList 1`] = `
     <!---->
   </a><a tabindex="0" href="#/" class="q-item q-item-type row no-wrap q-item--clickable q-link cursor-pointer q-focusable q-hoverable q-item--dense">
     <div tabindex="-1" class="q-focus-helper"></div>
-    <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" title="Co-operating" class="q-icon text-positive fas fa-circle" style="font-size:1.1em;"> </i></div>
+    <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" title="Co-operating" class="fas fa-circle q-icon text-positive" style="font-size:1.1em;"> </i></div>
     <div class="q-item__section column q-item__section--main justify-center">
       <div class="q-item__label items-baseline">
         Place 6
@@ -10026,7 +10026,7 @@ exports[`Storyshots Places PlaceList 1`] = `
     <!---->
   </a><a tabindex="0" href="#/" class="q-item q-item-type row no-wrap q-item--clickable q-link cursor-pointer q-focusable q-hoverable q-item--dense">
     <div tabindex="-1" class="q-focus-helper"></div>
-    <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" title="Co-operating" class="q-icon text-positive fas fa-circle" style="font-size:1.1em;"> </i></div>
+    <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" title="Co-operating" class="fas fa-circle q-icon text-positive" style="font-size:1.1em;"> </i></div>
     <div class="q-item__section column q-item__section--main justify-center">
       <div class="q-item__label items-baseline">
         Place 7
@@ -10036,7 +10036,7 @@ exports[`Storyshots Places PlaceList 1`] = `
     <!---->
   </a><a tabindex="0" href="#/" class="q-item q-item-type row no-wrap q-item--clickable q-link cursor-pointer q-focusable q-hoverable q-item--dense">
     <div tabindex="-1" class="q-focus-helper"></div>
-    <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" title="Co-operating" class="q-icon text-positive fas fa-circle" style="font-size:1.1em;"> </i></div>
+    <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" title="Co-operating" class="fas fa-circle q-icon text-positive" style="font-size:1.1em;"> </i></div>
     <div class="q-item__section column q-item__section--main justify-center">
       <div class="q-item__label items-baseline">
         Place 8
@@ -10051,7 +10051,7 @@ exports[`Storyshots Places PlaceList 1`] = `
 </div>
 `;
 
-exports[`Storyshots Profile TrustInfo 1`] = `<button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon notranslate material-icons">help_outline</i></span></span></button>`;
+exports[`Storyshots Profile TrustInfo 1`] = `<button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="notranslate material-icons q-icon">help_outline</i></span></span></button>`;
 
 exports[`Storyshots Profile member 1`] = `
 <div>
@@ -10074,29 +10074,29 @@ exports[`Storyshots Profile member 1`] = `
     </div>
     <div class="profile-info relative-position q-pt-sm q-card">
       <div class="user-actions">
-        <!----> <button tabindex="0" type="button" small="" title="Send a private message to User 172" class="q-btn q-btn-item non-selectable no-outline q-btn--standard q-btn--round bg-secondary text-white q-btn--actionable q-focusable q-hoverable q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon fas fa-comments"> </i></span></span></button> <button tabindex="0" type="button" small="" title="Is there a conflict with User 172?" class="q-btn q-btn-item non-selectable no-outline q-btn--standard q-btn--round bg-grey-5 text-white q-btn--actionable q-focusable q-hoverable q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon fas fa-frown-open"> </i></span></span></button> <button tabindex="0" type="button" title="Newcomer - 2 more trust needed" class="q-btn q-btn-item non-selectable no-outline karrot-button q-btn--standard q-btn--round bg-white text-white q-btn--actionable q-focusable q-hoverable q-btn--wrap small"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><svg viewBox="0 0 106 106" class="circle-progress"><path d="M 53,53 m 0,-47 a 47,47 0 1 1 0,94 a 47,47 0 1 1 0,-94" fill-opacity="0" stroke="currentColor" stroke-width="12px" stroke-linecap="round" class="text-primary" style="stroke-dasharray:295.31px, 295.31px;stroke-dashoffset:295.31px;transition:stroke-dashoffset 0.6s ease 0s, stroke 0.6s ease;"></path></svg> <div role="alert" class="q-badge flex inline items-center no-wrap q-badge--single-line bg-negative q-badge--floating">
+        <!----> <button tabindex="0" type="button" small="" title="Send a private message to User 172" class="q-btn q-btn-item non-selectable no-outline q-btn--standard q-btn--round bg-secondary text-white q-btn--actionable q-focusable q-hoverable q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="fas fa-comments q-icon"> </i></span></span></button> <button tabindex="0" type="button" small="" title="Is there a conflict with User 172?" class="q-btn q-btn-item non-selectable no-outline q-btn--standard q-btn--round bg-grey-5 text-white q-btn--actionable q-focusable q-hoverable q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="fas fa-frown-open q-icon"> </i></span></span></button> <button tabindex="0" type="button" title="Newcomer - 2 more trust needed" class="q-btn q-btn-item non-selectable no-outline karrot-button q-btn--standard q-btn--round bg-white text-white q-btn--actionable q-focusable q-hoverable q-btn--wrap small"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><svg viewBox="0 0 106 106" class="circle-progress"><path d="M 53,53 m 0,-47 a 47,47 0 1 1 0,94 a 47,47 0 1 1 0,-94" fill-opacity="0" stroke="currentColor" stroke-width="12px" stroke-linecap="round" class="text-primary" style="stroke-dasharray:295.31px, 295.31px;stroke-dashoffset:295.31px;transition:stroke-dashoffset 0.6s ease 0s, stroke 0.6s ease;"></path></svg> <div role="alert" class="q-badge flex inline items-center no-wrap q-badge--single-line bg-negative q-badge--floating">
     1
   </div> <!----></span></span></button>
       </div>
       <div class="q-list">
         <div class="q-item q-item-type row no-wrap">
-          <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">alternate_email</i></div>
+          <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">alternate_email</i></div>
           <div class="q-item__section column ellipsis q-item__section--main justify-center">
 
           </div>
         </div>
         <div class="q-item q-item-type row no-wrap">
-          <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-fw fa-envelope"> </i></div>
+          <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="fas fa-fw fa-envelope q-icon"> </i></div>
           <div class="q-item__section column ellipsis q-item__section--main justify-center"><a href="mailto:foo@foo.com">foo@foo.com</a></div>
         </div>
         <div class="q-item q-item-type row no-wrap">
-          <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-fw fa-phone"> </i></div>
+          <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="fas fa-fw fa-phone q-icon"> </i></div>
           <div class="q-item__section column q-item__section--main justify-center">
             123
           </div>
         </div>
         <div class="q-item q-item-type row no-wrap">
-          <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-fw fa-map-marker"> </i></div>
+          <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="fas fa-fw fa-map-marker q-icon"> </i></div>
           <div class="q-item__section column q-item__section--main justify-center">
             New Street 1
           </div>
@@ -10183,7 +10183,7 @@ exports[`Storyshots Profile non-member 1`] = `
   <div class="k-profile">
     <div role="alert" class="q-banner row items-center bg-warning text-white shadow-2 q-mb-sm q-pa-none" style="min-height:unset;">
       <div class="q-banner__avatar col-auto row items-center self-start">
-        <div class="q-pa-sm" style="background-color:rgba(0, 0, 0, .1);"><i aria-hidden="true" role="presentation" class="text-white q-icon notranslate material-icons" style="font-size:24px;">priority_high</i></div>
+        <div class="q-pa-sm" style="background-color:rgba(0, 0, 0, .1);"><i aria-hidden="true" role="presentation" class="text-white notranslate material-icons q-icon" style="font-size:24px;">priority_high</i></div>
       </div>
       <div class="q-banner__content col text-body2">
         User 171 is not member of Group 44.
@@ -10206,19 +10206,19 @@ exports[`Storyshots Profile non-member 1`] = `
     </div>
     <div class="profile-info relative-position q-pt-sm q-card">
       <div class="user-actions">
-        <!----> <button tabindex="0" type="button" small="" title="Send a private message to User 171" class="q-btn q-btn-item non-selectable no-outline q-btn--standard q-btn--round bg-secondary text-white q-btn--actionable q-focusable q-hoverable q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon fas fa-comments"> </i></span></span></button>
+        <!----> <button tabindex="0" type="button" small="" title="Send a private message to User 171" class="q-btn q-btn-item non-selectable no-outline q-btn--standard q-btn--round bg-secondary text-white q-btn--actionable q-focusable q-hoverable q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="fas fa-comments q-icon"> </i></span></span></button>
         <!---->
         <!---->
       </div>
       <div class="q-list">
         <div class="q-item q-item-type row no-wrap">
-          <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">alternate_email</i></div>
+          <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">alternate_email</i></div>
           <div class="q-item__section column ellipsis q-item__section--main justify-center">
 
           </div>
         </div>
         <div class="q-item q-item-type row no-wrap">
-          <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-fw fa-envelope"> </i></div>
+          <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="fas fa-fw fa-envelope q-icon"> </i></div>
           <div class="q-item__section column ellipsis q-item__section--main justify-center"><a href="mailto:foo@foo.com">foo@foo.com</a></div>
         </div>
         <!---->
@@ -10318,7 +10318,7 @@ exports[`Storyshots Settings Page Default 1`] = `
     </div>
     <div class="q-card__section q-card__section--vert">
       <div class="edit-box k-change-photo"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-field--standard q-field--float q-field--labeled q-field--auto-height q-field--with-bottom">
-          <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-camera"> </i></div>
+          <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-camera q-icon"> </i></div>
           <div class="q-field__inner relative-position col self-stretch">
             <div tabindex="-1" class="q-field__control relative-position row no-wrap">
               <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip">
@@ -10353,7 +10353,7 @@ exports[`Storyshots Settings Page Default 1`] = `
       <hr aria-orientation="horizontal" class="q-separator q-separator q-separator--horizontal">
       <div class="edit-box">
         <form><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--standard q-field--float q-field--labeled q-field--with-bottom">
-            <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-star"> </i></div>
+            <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-star q-icon"> </i></div>
             <div class="q-field__inner relative-position col self-stretch">
               <div tabindex="-1" class="q-field__control relative-position row no-wrap">
                 <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" aria-label="Name" id="f_80808080-8080-4080-8080-808080808080" type="text" value="Current User" class="q-field__native q-placeholder">
@@ -10366,10 +10366,24 @@ exports[`Storyshots Settings Page Default 1`] = `
                 </transition-stub>
               </div>
             </div>
+          </label> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--standard q-field--labeled q-field--with-bottom">
+            <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-at q-icon"> </i></div>
+            <div class="q-field__inner relative-position col self-stretch">
+              <div tabindex="-1" class="q-field__control relative-position row no-wrap">
+                <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" aria-label="Username" id="f_80808080-8080-4080-8080-808080808080" type="text" value="" class="q-field__native q-placeholder">
+                  <div class="q-field__label no-pointer-events absolute ellipsis">Username</div>
+                </div>
+              </div>
+              <div class="q-field__bottom row items-start q-field__bottom--animated">
+                <transition-stub name="q-transition--field-message">
+                  <div class="q-field__messages col"></div>
+                </transition-stub>
+              </div>
+            </div>
           </label>
           <div>
             <div class="relative-position q-mb-sm"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-textarea q-textarea--autogrow q-field--standard q-field--float q-field--labeled q-field--with-bottom">
-                <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">info</i></div>
+                <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">info</i></div>
                 <div class="q-field__inner relative-position col self-stretch">
                   <div tabindex="-1" class="q-field__control relative-position row no-wrap">
                     <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><textarea tabindex="0" rows="1" aria-label="About you" id="f_80808080-8080-4080-8080-808080808080" type="textarea" class="q-field__native q-placeholder" style="min-height:100px;">I am the current User!</textarea>
@@ -10386,7 +10400,7 @@ exports[`Storyshots Settings Page Default 1`] = `
                 <!----></span></span>
               </button></div>
           </div> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--standard q-field--labeled q-field--with-bottom">
-            <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-phone"> </i></div>
+            <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-phone q-icon"> </i></div>
             <div class="q-field__inner relative-position col self-stretch">
               <div tabindex="-1" class="q-field__control relative-position row no-wrap">
                 <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" aria-label="Phone number" id="f_80808080-8080-4080-8080-808080808080" type="tel" value="" class="q-field__native q-placeholder">
@@ -10401,14 +10415,14 @@ exports[`Storyshots Settings Page Default 1`] = `
             </div>
           </label>
           <div><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-select q-field--auto-height q-select--with-input q-select--without-chips q-select--single q-field--standard q-field--float q-field--labeled q-field--with-bottom">
-              <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-map-marker"> </i></div>
+              <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-map-marker q-icon"> </i></div>
               <div class="q-field__inner relative-position col self-stretch">
                 <div tabindex="-1" class="q-field__control relative-position row no-wrap">
                   <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip">
-                    <div class="q-field__native row items-center"><input type="search" role="combobox" aria-multiselectable="false" aria-expanded="false" aria-owns="f_80808080-8080-4080-8080-808080808080_lb" aria-activedescendant="f_80808080-8080-4080-8080-808080808080_-1" placeholder="Search" id="f_80808080-8080-4080-8080-808080808080" tabindex="0" value="Darmstadt, Regierungsbezirk Darmstadt, Hessen, Deutschland" class="q-field__input q-placeholder col q-field__input--padding"></div>
+                    <div placeholder="Search" class="q-field__native row items-center"><input type="search" placeholder="Search" id="f_80808080-8080-4080-8080-808080808080" tabindex="0" role="combobox" aria-multiselectable="false" aria-expanded="false" aria-owns="f_80808080-8080-4080-8080-808080808080_lb" aria-activedescendant="f_80808080-8080-4080-8080-808080808080_-1" value="Darmstadt, Regierungsbezirk Darmstadt, Hessen, Deutschland" class="q-field__input q-placeholder col q-field__input--padding"></div>
                     <div class="q-field__label no-pointer-events absolute ellipsis">Where you are from (not required)</div>
                   </div>
-                  <div class="q-field__append q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="cursor-pointer q-icon notranslate material-icons">cancel</i></div>
+                  <div class="q-field__append q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="cursor-pointer notranslate material-icons q-icon">cancel</i></div>
                 </div>
                 <div class="q-field__bottom row items-start q-field__bottom--animated">
                   <transition-stub name="q-transition--field-message">
@@ -10440,7 +10454,7 @@ exports[`Storyshots Settings Page Default 1`] = `
       </div>
     </div>
     <div class="q-card__section q-card__section--vert">
-      <div class="edit-box row justify-end"><button tabindex="0" type="button" title="Switch language" class="q-btn q-btn-item non-selectable no-outline k-locale-select q-btn--standard q-btn--rectangle q-btn--actionable q-focusable q-hoverable q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-icon fas fa-globe fa-fw"> </i> 
+      <div class="edit-box row justify-end"><button tabindex="0" type="button" title="Switch language" class="q-btn q-btn-item non-selectable no-outline k-locale-select q-btn--standard q-btn--rectangle q-btn--actionable q-focusable q-hoverable q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="fas fa-globe fa-fw q-icon"> </i> 
     English
    <!----></span></span></button></div>
     </div>
@@ -10454,7 +10468,7 @@ exports[`Storyshots Settings Page Default 1`] = `
     <div class="q-card__section q-card__section--vert">
       <div id="change-email" class="edit-box">
         <div>VerificationWarning has been mocked</div> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--standard q-field--labeled q-field--with-bottom">
-          <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-envelope"> </i></div>
+          <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-envelope q-icon"> </i></div>
           <div class="q-field__inner relative-position col self-stretch">
             <div tabindex="-1" class="q-field__control relative-position row no-wrap">
               <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" aria-label="E-mail" id="f_80808080-8080-4080-8080-808080808080" type="email" value="" class="q-field__native q-placeholder">
@@ -10468,7 +10482,7 @@ exports[`Storyshots Settings Page Default 1`] = `
             </div>
           </div>
         </label> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--standard q-field--labeled q-field--with-bottom">
-          <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-unlock"> </i></div>
+          <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-unlock q-icon"> </i></div>
           <div class="q-field__inner relative-position col self-stretch">
             <div tabindex="-1" class="q-field__control relative-position row no-wrap">
               <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" aria-label="Confirm your password" id="f_80808080-8080-4080-8080-808080808080" type="password" value="" class="q-field__native q-placeholder">
@@ -10491,7 +10505,7 @@ exports[`Storyshots Settings Page Default 1`] = `
       </div>
       <hr aria-orientation="horizontal" class="q-separator q-separator q-separator--horizontal">
       <div class="edit-box"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--standard q-field--labeled q-field--with-bottom">
-          <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-lock"> </i></div>
+          <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-lock q-icon"> </i></div>
           <div class="q-field__inner relative-position col self-stretch">
             <div tabindex="-1" class="q-field__control relative-position row no-wrap">
               <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" aria-label="New password" id="f_80808080-8080-4080-8080-808080808080" type="password" value="" class="q-field__native q-placeholder">
@@ -10505,7 +10519,7 @@ exports[`Storyshots Settings Page Default 1`] = `
             </div>
           </div>
         </label> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--standard q-field--labeled q-field--with-bottom">
-          <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-unlock"> </i></div>
+          <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-unlock q-icon"> </i></div>
           <div class="q-field__inner relative-position col self-stretch">
             <div tabindex="-1" class="q-field__control relative-position row no-wrap">
               <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" aria-label="Confirm your old password" id="f_80808080-8080-4080-8080-808080808080" type="password" value="" class="q-field__native q-placeholder">
@@ -10527,7 +10541,7 @@ exports[`Storyshots Settings Page Default 1`] = `
           </button></div>
       </div>
       <div class="q-card__actions q-card__actions--horiz row justify-start">
-        <div><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--rectangle text-negative q-btn--actionable q-focusable q-hoverable q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon on-left fas fa-trash-alt"> </i><span class="block">Delete account</span></span></span>
+        <div><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--rectangle text-negative q-btn--actionable q-focusable q-hoverable q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="fas fa-trash-alt q-icon on-left"> </i><span class="block">Delete account</span></span></span>
             <transition-stub name="q-transition--fade"></transition-stub>
           </button>
           <!---->
@@ -10699,15 +10713,15 @@ exports[`Storyshots Settings Page verification warning and failed email deliveri
 
 exports[`Storyshots Sidenav Group 1`] = `
 <div class="k-sidenav-box">
-  <div inverted="" class="q-toolbar row no-wrap items-center toolbar"><i aria-hidden="true" role="presentation" class="q-icon fas fa-fw fa-home"> </i>
+  <div inverted="" class="q-toolbar row no-wrap items-center toolbar"><i aria-hidden="true" role="presentation" class="fas fa-fw fa-home q-icon"> </i>
     <div class="q-toolbar__title ellipsis">
       Home
     </div>
-    <div><a tabindex="0" href="#/" title="Description" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense" style="font-size:10px;"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-icon fas fa-info-circle fa-fw"> </i></span></span></a> <button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense" style="font-size:10px;"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-icon fas fa-fw fa-ellipsis-v"> </i> <!----></span></span></button></div>
+    <div><a tabindex="0" href="#/" title="Description" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense" style="font-size:10px;"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="fas fa-info-circle fa-fw q-icon"> </i></span></span></a> <button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense" style="font-size:10px;"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="fas fa-fw fa-ellipsis-v q-icon"> </i> <!----></span></span></button></div>
   </div>
   <div class="q-list q-list--dense"><a tabindex="0" href="#/" class="q-item q-item-type row no-wrap q-item--clickable q-link cursor-pointer q-focusable q-hoverable">
       <div tabindex="-1" class="q-focus-helper"></div>
-      <div class="q-item__section column text-center q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-bullhorn" style="font-size:1.1em;"> </i></div>
+      <div class="q-item__section column text-center q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="fas fa-bullhorn q-icon" style="font-size:1.1em;"> </i></div>
       <div class="q-item__section column q-item__section--main justify-center">
         Wall
       </div>
@@ -10719,7 +10733,7 @@ exports[`Storyshots Sidenav Group 1`] = `
       </div>
     </a><a tabindex="0" href="#/" class="q-item q-item-type row no-wrap q-item--clickable q-link cursor-pointer q-focusable q-hoverable">
       <div tabindex="-1" class="q-focus-helper"></div>
-      <div class="q-item__section column text-center q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-asterisk" style="font-size:1.1em;"> </i></div>
+      <div class="q-item__section column text-center q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="fas fa-asterisk q-icon" style="font-size:1.1em;"> </i></div>
       <div class="q-item__section column q-item__section--main justify-center">
         Activities
       </div>
@@ -10727,7 +10741,7 @@ exports[`Storyshots Sidenav Group 1`] = `
       <!---->
     </a><a tabindex="0" href="#/" class="q-item q-item-type row no-wrap q-item--clickable q-link cursor-pointer q-focusable q-hoverable">
       <div tabindex="-1" class="q-focus-helper"></div>
-      <div class="q-item__section column text-center q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-reply" style="font-size:1.1em;"> </i></div>
+      <div class="q-item__section column text-center q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="fas fa-reply q-icon" style="font-size:1.1em;"> </i></div>
       <div class="q-item__section column q-item__section--main justify-center">
         Feedback
       </div>
@@ -10735,7 +10749,7 @@ exports[`Storyshots Sidenav Group 1`] = `
       <!---->
     </a><a tabindex="0" href="#/" class="q-item q-item-type row no-wrap q-item--clickable q-link cursor-pointer q-focusable q-hoverable">
       <div tabindex="-1" class="q-focus-helper"></div>
-      <div class="q-item__section column text-center q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-users" style="font-size:1.1em;"> </i></div>
+      <div class="q-item__section column text-center q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="fas fa-users q-icon" style="font-size:1.1em;"> </i></div>
       <div class="q-item__section column q-item__section--main justify-center">
         Members
       </div>
@@ -10743,7 +10757,7 @@ exports[`Storyshots Sidenav Group 1`] = `
       <!---->
     </a><a tabindex="0" href="#/" class="q-item q-item-type row no-wrap q-item--clickable q-link cursor-pointer q-focusable q-hoverable">
       <div tabindex="-1" class="q-focus-helper"></div>
-      <div class="q-item__section column text-center q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-icon far fa-clock" style="font-size:1.1em;"> </i></div>
+      <div class="q-item__section column text-center q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="far fa-clock q-icon" style="font-size:1.1em;"> </i></div>
       <div class="q-item__section column q-item__section--main justify-center">
         History
       </div>
@@ -10753,7 +10767,7 @@ exports[`Storyshots Sidenav Group 1`] = `
   <!---->
   <div tabindex="0" class="q-item q-item-type row no-wrap more-button q-item--clickable q-link cursor-pointer q-focusable q-hoverable q-item--dense">
     <div tabindex="-1" class="q-focus-helper"></div>
-    <div class="q-item__section column text-center q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-arrow-down" style="font-size:1.1em;"> </i></div>
+    <div class="q-item__section column text-center q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="fas fa-arrow-down q-icon" style="font-size:1.1em;"> </i></div>
     <div class="q-item__section column q-item__section--main justify-center">
       Show more
     </div>
@@ -10765,14 +10779,14 @@ exports[`Storyshots Sidenav Group 1`] = `
 exports[`Storyshots Sidenav GroupOptions 1`] = `
 <div class="q-list q-list--dense"><a tabindex="0" href="#/" class="q-item q-item-type row no-wrap q-item--clickable q-link cursor-pointer q-focusable q-hoverable">
     <div tabindex="-1" class="q-focus-helper"></div>
-    <div class="q-item__section column text-center q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-pencil-alt fa-fw" style="font-size:1.1em;"> </i></div>
+    <div class="q-item__section column text-center q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="fas fa-pencil-alt fa-fw q-icon" style="font-size:1.1em;"> </i></div>
     <div class="q-item__section column q-item__section--main justify-center">
       Edit group
     </div>
   </a>
   <div tabindex="0" class="q-item q-item-type row no-wrap q-item--clickable q-link cursor-pointer q-focusable q-hoverable">
     <div tabindex="-1" class="q-focus-helper"></div>
-    <div class="q-item__section column text-center q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-sign-out-alt fa-fw" style="font-size:1.1em;"> </i></div>
+    <div class="q-item__section column text-center q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="fas fa-sign-out-alt fa-fw q-icon" style="font-size:1.1em;"> </i></div>
     <div class="q-item__section column q-item__section--main justify-center">
       Leave group...
     </div>
@@ -10803,14 +10817,14 @@ exports[`Storyshots Sidenav Map 1`] = `
 exports[`Storyshots Sidenav Mobile 1`] = `
 <div>
   <div class="k-sidenav-box">
-    <div inverted="" class="q-toolbar row no-wrap items-center toolbar"><i aria-hidden="true" role="presentation" class="q-icon fas fa-fw fa-user-circle"> </i>
+    <div inverted="" class="q-toolbar row no-wrap items-center toolbar"><i aria-hidden="true" role="presentation" class="fas fa-fw fa-user-circle q-icon"> </i>
       <div class="q-toolbar__title ellipsis">
         Account
       </div>
     </div>
     <div class="q-list q-list--dense"><a tabindex="0" href="#/" class="q-item q-item-type row no-wrap q-item--clickable q-link cursor-pointer q-focusable q-hoverable">
         <div tabindex="-1" class="q-focus-helper"></div>
-        <div class="q-item__section column text-center q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-user fa-fw" style="font-size:1.1em;"> </i></div>
+        <div class="q-item__section column text-center q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="fas fa-user fa-fw q-icon" style="font-size:1.1em;"> </i></div>
         <div class="q-item__section column q-item__section--main justify-center">
           Visit your profile
         </div>
@@ -10818,7 +10832,7 @@ exports[`Storyshots Sidenav Mobile 1`] = `
         <!---->
       </a><a tabindex="0" href="#/" class="q-item q-item-type row no-wrap q-item--clickable q-link cursor-pointer q-focusable q-hoverable">
         <div tabindex="-1" class="q-focus-helper"></div>
-        <div class="q-item__section column text-center q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-exchange-alt fa-fw" style="font-size:1.1em;"> </i></div>
+        <div class="q-item__section column text-center q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="fas fa-exchange-alt fa-fw q-icon" style="font-size:1.1em;"> </i></div>
         <div class="q-item__section column q-item__section--main justify-center">
           Change group
         </div>
@@ -10826,7 +10840,7 @@ exports[`Storyshots Sidenav Mobile 1`] = `
         <!---->
       </a><a tabindex="0" href="#/" class="q-item q-item-type row no-wrap q-item--clickable q-link cursor-pointer q-focusable q-hoverable">
         <div tabindex="-1" class="q-focus-helper"></div>
-        <div class="q-item__section column text-center q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-cog fa-fw" style="font-size:1.1em;"> </i></div>
+        <div class="q-item__section column text-center q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="fas fa-cog fa-fw q-icon" style="font-size:1.1em;"> </i></div>
         <div class="q-item__section column q-item__section--main justify-center">
           Settings
         </div>
@@ -10835,7 +10849,7 @@ exports[`Storyshots Sidenav Mobile 1`] = `
       </a>
       <div tabindex="0" class="q-item q-item-type row no-wrap q-item--clickable q-link cursor-pointer q-focusable q-hoverable">
         <div tabindex="-1" class="q-focus-helper"></div>
-        <div class="q-item__section column text-center q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-icon fas fa-sign-out-alt fa-fw" style="font-size:1.1em;"> </i></div>
+        <div class="q-item__section column text-center q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="fas fa-sign-out-alt fa-fw q-icon" style="font-size:1.1em;"> </i></div>
         <div class="q-item__section column q-item__section--main justify-center">
           Logout
         </div>
@@ -10849,7 +10863,7 @@ exports[`Storyshots Sidenav Mobile 1`] = `
 
 exports[`Storyshots Sidenav Places 1`] = `
 <div class="k-sidenav-box">
-  <div inverted="" class="q-toolbar row no-wrap items-center toolbar"><i aria-hidden="true" role="presentation" class="q-icon fas fa-fw fa-circle"> </i>
+  <div inverted="" class="q-toolbar row no-wrap items-center toolbar"><i aria-hidden="true" role="presentation" class="fas fa-fw fa-circle q-icon"> </i>
     <div class="q-toolbar__title ellipsis">
       Places
     </div>
@@ -10865,7 +10879,7 @@ exports[`Storyshots Sidenav Places 1`] = `
   </div>
   <div class="q-list"><a tabindex="0" href="#/" class="q-item q-item-type row no-wrap q-item--clickable q-link cursor-pointer q-focusable q-hoverable q-item--dense">
       <div tabindex="-1" class="q-focus-helper"></div>
-      <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" title="Co-operating" class="q-icon text-positive fas fa-circle" style="font-size:1.1em;"> </i></div>
+      <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" title="Co-operating" class="fas fa-circle q-icon text-positive" style="font-size:1.1em;"> </i></div>
       <div class="q-item__section column q-item__section--main justify-center">
         <div class="q-item__label items-baseline">
           Place 9
@@ -10875,7 +10889,7 @@ exports[`Storyshots Sidenav Places 1`] = `
       <!---->
     </a><a tabindex="0" href="#/" class="q-item q-item-type row no-wrap q-item--clickable q-link cursor-pointer q-focusable q-hoverable q-item--dense">
       <div tabindex="-1" class="q-focus-helper"></div>
-      <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" title="Co-operating" class="q-icon text-positive fas fa-circle" style="font-size:1.1em;"> </i></div>
+      <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" title="Co-operating" class="fas fa-circle q-icon text-positive" style="font-size:1.1em;"> </i></div>
       <div class="q-item__section column q-item__section--main justify-center">
         <div class="q-item__label items-baseline">
           Place 10
@@ -10885,7 +10899,7 @@ exports[`Storyshots Sidenav Places 1`] = `
       <!---->
     </a><a tabindex="0" href="#/" class="q-item q-item-type row no-wrap q-item--clickable q-link cursor-pointer q-focusable q-hoverable q-item--dense">
       <div tabindex="-1" class="q-focus-helper"></div>
-      <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" title="Co-operating" class="q-icon text-positive fas fa-circle" style="font-size:1.1em;"> </i></div>
+      <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" title="Co-operating" class="fas fa-circle q-icon text-positive" style="font-size:1.1em;"> </i></div>
       <div class="q-item__section column q-item__section--main justify-center">
         <div class="q-item__label items-baseline">
           Place 11
@@ -10895,7 +10909,7 @@ exports[`Storyshots Sidenav Places 1`] = `
       <!---->
     </a><a tabindex="0" href="#/" class="q-item q-item-type row no-wrap q-item--clickable q-link cursor-pointer q-focusable q-hoverable q-item--dense">
       <div tabindex="-1" class="q-focus-helper"></div>
-      <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" title="Co-operating" class="q-icon text-positive fas fa-circle" style="font-size:1.1em;"> </i></div>
+      <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" title="Co-operating" class="fas fa-circle q-icon text-positive" style="font-size:1.1em;"> </i></div>
       <div class="q-item__section column q-item__section--main justify-center">
         <div class="q-item__label items-baseline">
           Place 12
@@ -10905,7 +10919,7 @@ exports[`Storyshots Sidenav Places 1`] = `
       <!---->
     </a><a tabindex="0" href="#/" class="q-item q-item-type row no-wrap q-item--clickable q-link cursor-pointer q-focusable q-hoverable q-item--dense">
       <div tabindex="-1" class="q-focus-helper"></div>
-      <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" title="Co-operating" class="q-icon text-positive fas fa-circle" style="font-size:1.1em;"> </i></div>
+      <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" title="Co-operating" class="fas fa-circle q-icon text-positive" style="font-size:1.1em;"> </i></div>
       <div class="q-item__section column q-item__section--main justify-center">
         <div class="q-item__label items-baseline">
           Place 13
@@ -10925,7 +10939,7 @@ exports[`Storyshots Signup empty 1`] = `
 <div>
   <form name="signup">
     <div class="q-gutter-md"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--outlined q-field--labeled">
-        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon text-grey-5 fas fa-user"> </i></div>
+        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-user q-icon text-grey-5"> </i></div>
         <div class="q-field__inner relative-position col self-stretch">
           <div tabindex="-1" class="q-field__control relative-position row no-wrap bg-white">
             <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" data-autofocus="true" aria-label="Display Name" autocorrect="off" autocapitalize="off" spellcheck="false" id="f_80808080-8080-4080-8080-808080808080" type="text" class="q-field__native q-placeholder">
@@ -10934,7 +10948,7 @@ exports[`Storyshots Signup empty 1`] = `
           </div>
         </div>
       </label> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--outlined q-field--labeled">
-        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon text-grey-5 notranslate material-icons">alternate_email</i></div>
+        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon text-grey-5">alternate_email</i></div>
         <div class="q-field__inner relative-position col self-stretch">
           <div tabindex="-1" class="q-field__control relative-position row no-wrap bg-white">
             <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" aria-label="Username" autocorrect="off" autocapitalize="off" spellcheck="false" id="f_80808080-8080-4080-8080-808080808080" type="text" class="q-field__native q-placeholder">
@@ -10943,7 +10957,7 @@ exports[`Storyshots Signup empty 1`] = `
           </div>
         </div>
       </label> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--outlined q-field--float q-field--labeled">
-        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon text-grey-5 fas fa-envelope"> </i></div>
+        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-envelope q-icon text-grey-5"> </i></div>
         <div class="q-field__inner relative-position col self-stretch">
           <div tabindex="-1" class="q-field__control relative-position row no-wrap bg-white">
             <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" aria-label="E-mail" autocorrect="off" autocapitalize="off" spellcheck="false" id="f_80808080-8080-4080-8080-808080808080" type="email" value="default@example.com" class="q-field__native q-placeholder">
@@ -10952,7 +10966,7 @@ exports[`Storyshots Signup empty 1`] = `
           </div>
         </div>
       </label> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--outlined q-field--labeled">
-        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon text-grey-5 fas fa-lock"> </i></div>
+        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-lock q-icon text-grey-5"> </i></div>
         <div class="q-field__inner relative-position col self-stretch">
           <div tabindex="-1" class="q-field__control relative-position row no-wrap bg-white">
             <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" aria-label="Password" autocorrect="off" autocapitalize="off" spellcheck="false" id="f_80808080-8080-4080-8080-808080808080" type="password" class="q-field__native q-placeholder">
@@ -10978,7 +10992,7 @@ exports[`Storyshots Signup error 1`] = `
 <div>
   <form name="signup">
     <div class="q-gutter-md"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--outlined q-field--labeled">
-        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon text-grey-5 fas fa-user"> </i></div>
+        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-user q-icon text-grey-5"> </i></div>
         <div class="q-field__inner relative-position col self-stretch">
           <div tabindex="-1" class="q-field__control relative-position row no-wrap bg-white">
             <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" data-autofocus="true" aria-label="Display Name" autocorrect="off" autocapitalize="off" spellcheck="false" id="f_80808080-8080-4080-8080-808080808080" type="text" class="q-field__native q-placeholder">
@@ -10987,7 +11001,7 @@ exports[`Storyshots Signup error 1`] = `
           </div>
         </div>
       </label> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--outlined q-field--labeled">
-        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon text-grey-5 notranslate material-icons">alternate_email</i></div>
+        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon text-grey-5">alternate_email</i></div>
         <div class="q-field__inner relative-position col self-stretch">
           <div tabindex="-1" class="q-field__control relative-position row no-wrap bg-white">
             <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" aria-label="Username" autocorrect="off" autocapitalize="off" spellcheck="false" id="f_80808080-8080-4080-8080-808080808080" type="text" class="q-field__native q-placeholder">
@@ -10996,13 +11010,13 @@ exports[`Storyshots Signup error 1`] = `
           </div>
         </div>
       </label> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--outlined q-field--highlighted q-field--float q-field--labeled q-field--error">
-        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon text-grey-5 fas fa-envelope"> </i></div>
+        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-envelope q-icon text-grey-5"> </i></div>
         <div class="q-field__inner relative-position col self-stretch">
           <div tabindex="-1" class="q-field__control relative-position row no-wrap text-negative bg-white">
             <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" aria-label="E-mail" autocorrect="off" autocapitalize="off" spellcheck="false" id="f_80808080-8080-4080-8080-808080808080" type="email" value="default@example.com" class="q-field__native q-placeholder">
               <div class="q-field__label no-pointer-events absolute ellipsis">E-mail</div>
             </div>
-            <div class="q-field__append q-field__marginal row no-wrap items-center q-anchor--skip"><i aria-hidden="true" role="presentation" class="q-icon text-negative notranslate material-icons">error</i></div>
+            <div class="q-field__append q-field__marginal row no-wrap items-center q-anchor--skip"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon text-negative">error</i></div>
           </div>
           <div class="q-field__bottom row items-start q-field__bottom--stale">
             <div class="q-field__messages col">
@@ -11011,7 +11025,7 @@ exports[`Storyshots Signup error 1`] = `
           </div>
         </div>
       </label> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--outlined q-field--labeled">
-        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon text-grey-5 fas fa-lock"> </i></div>
+        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-lock q-icon text-grey-5"> </i></div>
         <div class="q-field__inner relative-position col self-stretch">
           <div tabindex="-1" class="q-field__control relative-position row no-wrap bg-white">
             <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" aria-label="Password" autocorrect="off" autocapitalize="off" spellcheck="false" id="f_80808080-8080-4080-8080-808080808080" type="password" class="q-field__native q-placeholder">
@@ -11037,7 +11051,7 @@ exports[`Storyshots Signup pending 1`] = `
 <div>
   <form name="signup">
     <div class="q-gutter-md"><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--outlined q-field--labeled">
-        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon text-grey-5 fas fa-user"> </i></div>
+        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-user q-icon text-grey-5"> </i></div>
         <div class="q-field__inner relative-position col self-stretch">
           <div tabindex="-1" class="q-field__control relative-position row no-wrap bg-white">
             <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" data-autofocus="true" aria-label="Display Name" autocorrect="off" autocapitalize="off" spellcheck="false" id="f_80808080-8080-4080-8080-808080808080" type="text" class="q-field__native q-placeholder">
@@ -11046,7 +11060,7 @@ exports[`Storyshots Signup pending 1`] = `
           </div>
         </div>
       </label> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--outlined q-field--labeled">
-        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon text-grey-5 notranslate material-icons">alternate_email</i></div>
+        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon text-grey-5">alternate_email</i></div>
         <div class="q-field__inner relative-position col self-stretch">
           <div tabindex="-1" class="q-field__control relative-position row no-wrap bg-white">
             <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" aria-label="Username" autocorrect="off" autocapitalize="off" spellcheck="false" id="f_80808080-8080-4080-8080-808080808080" type="text" class="q-field__native q-placeholder">
@@ -11055,7 +11069,7 @@ exports[`Storyshots Signup pending 1`] = `
           </div>
         </div>
       </label> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--outlined q-field--float q-field--labeled">
-        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon text-grey-5 fas fa-envelope"> </i></div>
+        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-envelope q-icon text-grey-5"> </i></div>
         <div class="q-field__inner relative-position col self-stretch">
           <div tabindex="-1" class="q-field__control relative-position row no-wrap bg-white">
             <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" aria-label="E-mail" autocorrect="off" autocapitalize="off" spellcheck="false" id="f_80808080-8080-4080-8080-808080808080" type="email" value="default@example.com" class="q-field__native q-placeholder">
@@ -11064,7 +11078,7 @@ exports[`Storyshots Signup pending 1`] = `
           </div>
         </div>
       </label> <label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--outlined q-field--labeled">
-        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon text-grey-5 fas fa-lock"> </i></div>
+        <div class="q-field__before q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="fas fa-lock q-icon text-grey-5"> </i></div>
         <div class="q-field__inner relative-position col self-stretch">
           <div tabindex="-1" class="q-field__control relative-position row no-wrap bg-white">
             <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" aria-label="Password" autocorrect="off" autocapitalize="off" spellcheck="false" id="f_80808080-8080-4080-8080-808080808080" type="password" class="q-field__native q-placeholder">
@@ -11110,11 +11124,11 @@ exports[`Storyshots Topbar Search 1`] = `
 <div><label for="f_80808080-8080-4080-8080-808080808080" class="q-field q-validation-component row no-wrap items-start q-input q-field--standout q-field--dense q-field--dark">
     <div class="q-field__inner relative-position col self-stretch">
       <div tabindex="-1" class="q-field__control relative-position row no-wrap">
-        <div class="q-field__prepend q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="q-icon notranslate material-icons">search</i></div>
+        <div class="q-field__prepend q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon">search</i></div>
         <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><input tabindex="0" data-autofocus="true" placeholder="Search" id="f_80808080-8080-4080-8080-808080808080" type="search" value="" class="q-field__native q-placeholder">
           <!---->
         </div>
-        <div class="q-field__append q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="cursor-pointer q-icon notranslate material-icons">cancel</i></div>
+        <div class="q-field__append q-field__marginal row no-wrap items-center"><i aria-hidden="true" role="presentation" class="cursor-pointer notranslate material-icons q-icon">cancel</i></div>
       </div>
     </div>
   </label></div>
@@ -11235,7 +11249,7 @@ exports[`Storyshots Unsubscribe error 1`] = `
 exports[`Storyshots Unsubscribe invalid token 1`] = `
 <div class="edit-box bg-primary splash-md">
   <div class="bg-white shadow-6 q-py-md q-px-sm">
-    <h2><i aria-hidden="true" role="presentation" class="q-mx-sm q-icon fas fa-sad-tear"> </i>
+    <h2><i aria-hidden="true" role="presentation" class="q-mx-sm fas fa-sad-tear q-icon"> </i>
       Sorry, the link you've opened is invalid.
     </h2>
   </div>
@@ -11245,7 +11259,7 @@ exports[`Storyshots Unsubscribe invalid token 1`] = `
 exports[`Storyshots Unsubscribe success 1`] = `
 <div class="edit-box bg-primary splash-md">
   <div class="bg-white shadow-6 q-py-md q-px-sm">
-    <h2><i aria-hidden="true" role="presentation" class="q-mx-sm q-icon fas fa-smile-beam"> </i>
+    <h2><i aria-hidden="true" role="presentation" class="q-mx-sm fas fa-smile-beam q-icon"> </i>
       You were successfully unsubscribed!
     </h2>
   </div>
@@ -11495,7 +11509,7 @@ exports[`Storyshots UserList default 1`] = `
       <div class="q-expansion-item__container relative-position">
         <div tabindex="0" class="q-item q-item-type row no-wrap q-item--clickable q-link cursor-pointer q-focusable q-hoverable">
           <div tabindex="-1" class="q-focus-helper"></div>
-          <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-mr-xs q-icon fas fa-bed"> </i></div>
+          <div class="q-item__section column q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-mr-xs fas fa-bed q-icon"> </i></div>
           <div class="q-item__section column q-item__section--main justify-center">
             <div class="q-item__label">
               Inactive
@@ -11504,8 +11518,8 @@ exports[`Storyshots UserList default 1`] = `
               5 Members
             </div>
           </div>
-          <div class="q-item__section column q-item__section--side justify-center"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon notranslate material-icons">help_outline</i></span></span></button></div>
-          <div class="q-item__section column q-focusable relative-position cursor-pointer q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-expansion-item__toggle-icon q-icon notranslate material-icons">keyboard_arrow_down</i></div>
+          <div class="q-item__section column q-item__section--side justify-center"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="notranslate material-icons q-icon">help_outline</i></span></span></button></div>
+          <div class="q-item__section column q-focusable relative-position cursor-pointer q-item__section--side justify-center"><i aria-hidden="true" role="presentation" class="q-expansion-item__toggle-icon notranslate material-icons q-icon">keyboard_arrow_down</i></div>
         </div>
         <transition-stub>
           <div class="q-expansion-item__content relative-position" style="display:none;"></div>
@@ -11535,7 +11549,7 @@ exports[`Storyshots VerifyMail error 1`] = `
   <!---->
   <p><i class="fas fa-exclamation-triangle"></i>
     this error is returned by the server
-  </p> <a><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--push q-btn--rectangle bg-secondary text-white q-btn--actionable q-focusable q-hoverable q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><span></span><i aria-hidden="true" role="img" class="q-icon fas fa-home"> </i></span></span></button></a>
+  </p> <a><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--push q-btn--rectangle bg-secondary text-white q-btn--actionable q-focusable q-hoverable q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><span></span><i aria-hidden="true" role="img" class="fas fa-home q-icon"> </i></span></span></button></a>
 </div>
 `;
 
@@ -11556,7 +11570,7 @@ exports[`Storyshots VerifyMail pending 1`] = `
       </circle>
     </svg></div>
   <!---->
-  <!----> <a><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--push q-btn--rectangle bg-secondary text-white q-btn--actionable q-focusable q-hoverable q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><span></span><i aria-hidden="true" role="img" class="q-icon fas fa-home"> </i></span></span></button></a>
+  <!----> <a><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--push q-btn--rectangle bg-secondary text-white q-btn--actionable q-focusable q-hoverable q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><span></span><i aria-hidden="true" role="img" class="fas fa-home q-icon"> </i></span></span></button></a>
 </div>
 `;
 
@@ -11579,14 +11593,14 @@ exports[`Storyshots VerifyMail success 1`] = `
   <p>
     Your e-mail address was successfully verified!
   </p>
-  <!----> <a><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--push q-btn--rectangle bg-secondary text-white q-btn--actionable q-focusable q-hoverable q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><span></span><i aria-hidden="true" role="img" class="q-icon fas fa-home"> </i></span></span></button></a>
+  <!----> <a><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--push q-btn--rectangle bg-secondary text-white q-btn--actionable q-focusable q-hoverable q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><span></span><i aria-hidden="true" role="img" class="fas fa-home q-icon"> </i></span></span></button></a>
 </div>
 `;
 
 exports[`Storyshots WallConversation default 1`] = `
 <div>
   <div class="q-infinite-scroll">
-    <div class="bg-white desktop-margin relative-position q-pb-md q-list q-list--bordered"><button tabindex="0" type="button" title="How do you want to receive notifications about new messages in this conversation/thread?" class="q-btn q-btn-item non-selectable no-outline actionButton q-btn--standard q-btn--round bg-secondary text-white q-btn--actionable q-focusable q-hoverable q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-icon fas fa-fw fa-envelope" style="font-size:1.4em;"> </i> <!----></span></span></button>
+    <div class="bg-white desktop-margin relative-position q-pb-md q-list q-list--bordered"><button tabindex="0" type="button" title="How do you want to receive notifications about new messages in this conversation/thread?" class="q-btn q-btn-item non-selectable no-outline actionButton q-btn--standard q-btn--round bg-secondary text-white q-btn--actionable q-focusable q-hoverable q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="fas fa-fw fa-envelope q-icon" style="font-size:1.4em;"> </i> <!----></span></span></button>
       <div>
         <div class="q-item q-item-type row no-wrap">
           <div class="q-item__section column q-mt-xs q-pr-sm q-item__section--top q-item__section--side justify-start">
@@ -11601,7 +11615,7 @@ exports[`Storyshots WallConversation default 1`] = `
                     <div class="q-field__inner relative-position col self-stretch">
                       <div tabindex="-1" class="q-field__control relative-position row no-wrap">
                         <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><textarea tabindex="0" rows="1" placeholder="Write a message..." id="f_80808080-8080-4080-8080-808080808080" type="textarea" class="q-field__native q-placeholder" style="min-height:unset;max-height:320px;"></textarea></div>
-                        <div class="q-field__append q-field__marginal row no-wrap items-center"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon fas fa-image"> </i></span></span></button>
+                        <div class="q-field__append q-field__marginal row no-wrap items-center"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="fas fa-image q-icon"> </i></span></span></button>
                           <!---->
                           <!---->
                         </div>
@@ -11831,7 +11845,7 @@ exports[`Storyshots WallConversation default 1`] = `
 exports[`Storyshots WallConversation unread 1`] = `
 <div>
   <div class="q-infinite-scroll">
-    <div class="bg-white desktop-margin relative-position q-pb-md q-list q-list--bordered"><button tabindex="0" type="button" title="How do you want to receive notifications about new messages in this conversation/thread?" class="q-btn q-btn-item non-selectable no-outline actionButton q-btn--standard q-btn--round bg-secondary text-white q-btn--actionable q-focusable q-hoverable q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="q-icon fas fa-fw fa-envelope" style="font-size:1.4em;"> </i> <!----></span></span></button>
+    <div class="bg-white desktop-margin relative-position q-pb-md q-list q-list--bordered"><button tabindex="0" type="button" title="How do you want to receive notifications about new messages in this conversation/thread?" class="q-btn q-btn-item non-selectable no-outline actionButton q-btn--standard q-btn--round bg-secondary text-white q-btn--actionable q-focusable q-hoverable q-btn--wrap"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="presentation" class="fas fa-fw fa-envelope q-icon" style="font-size:1.4em;"> </i> <!----></span></span></button>
       <div>
         <div class="q-item q-item-type row no-wrap">
           <div class="q-item__section column q-mt-xs q-pr-sm q-item__section--top q-item__section--side justify-start">
@@ -11846,7 +11860,7 @@ exports[`Storyshots WallConversation unread 1`] = `
                     <div class="q-field__inner relative-position col self-stretch">
                       <div tabindex="-1" class="q-field__control relative-position row no-wrap">
                         <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip"><textarea tabindex="0" rows="1" placeholder="Write a message..." id="f_80808080-8080-4080-8080-808080808080" type="textarea" class="q-field__native q-placeholder" style="min-height:unset;max-height:320px;"></textarea></div>
-                        <div class="q-field__append q-field__marginal row no-wrap items-center"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="q-icon fas fa-image"> </i></span></span></button>
+                        <div class="q-field__append q-field__marginal row no-wrap items-center"><button tabindex="0" type="button" class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--round q-btn--actionable q-focusable q-hoverable q-btn--wrap q-btn--dense"><span class="q-focus-helper"></span><span class="q-btn__wrapper col row q-anchor--skip"><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i aria-hidden="true" role="img" class="fas fa-image q-icon"> </i></span></span></button>
                           <!---->
                           <!---->
                         </div>
@@ -11886,7 +11900,7 @@ exports[`Storyshots WallConversation unread 1`] = `
         <!---->
       </div>
       <div role="alert" class="q-banner row items-center bg-secondary text-white q-mt-sm" style="min-height:unset;">
-        <div class="q-banner__avatar col-auto row items-center self-start"><i aria-hidden="true" role="presentation" class="q-icon text-white notranslate material-icons" style="font-size:1.5em;">star</i></div>
+        <div class="q-banner__avatar col-auto row items-center self-start"><i aria-hidden="true" role="presentation" class="notranslate material-icons q-icon text-white" style="font-size:1.5em;">star</i></div>
         <div class="q-banner__content col text-body2">
           <div class="row justify-between items-center"><small>
               You have one unread message.

--- a/src/authuser/components/Settings/ProfileEdit.vue
+++ b/src/authuser/components/Settings/ProfileEdit.vue
@@ -16,6 +16,18 @@
         </template>
       </QInput>
 
+      <QInput
+        v-model="edit.username"
+        :label="$t('USERDETAIL.USERNAME')"
+        :error="hasUsernameError"
+        :error-message="usernameError"
+        @blur="$v.edit.username.$touch"
+      >
+        <template #before>
+          <QIcon name="fas fa-at" />
+        </template>
+      </QInput>
+
       <MarkdownInput
         v-model="edit.description"
         icon="info"
@@ -86,7 +98,7 @@ import MarkdownInput from '@/utils/components/MarkdownInput'
 import editMixin from '@/utils/mixins/editMixin'
 import statusMixin from '@/utils/mixins/statusMixin'
 import { validationMixin } from 'vuelidate'
-import { required, minLength, maxLength } from 'vuelidate/lib/validators'
+import { required, minLength, maxLength, helpers } from 'vuelidate/lib/validators'
 
 export default {
   components: {
@@ -128,6 +140,20 @@ export default {
       }
       return this.firstError('displayName')
     },
+    hasUsernameError () {
+      return !!this.usernameError
+    },
+    usernameError () {
+      if (this.$v.edit.username.$error) {
+        const m = this.$v.edit.username
+        if (!m.required) return this.$t('VALIDATION.REQUIRED')
+        if (!m.valid) return this.$t('VALIDATION.VALID_USERNAME')
+      }
+      const error = this.firstError('username')
+      if (error === 'username_invalid') return this.$t('VALIDATION.VALID_USERNAME')
+      if (error === 'username_taken') return this.$t('VALIDATION.TAKEN')
+      return error
+    },
   },
   methods: {
     maybeSave () {
@@ -143,6 +169,10 @@ export default {
         required,
         minLength: minLength(3),
         maxLength: maxLength(80),
+      },
+      username: {
+        required,
+        valid: helpers.regex('valid', /^[\w.+-]+$/), // should correspond to backend one
       },
     },
   },

--- a/src/locales/locale-en.json
+++ b/src/locales/locale-en.json
@@ -842,6 +842,7 @@
   "USERDETAIL": {
     "DESCRIPTION": "About you",
     "DISPLAY_NAME": "Name",
+    "USERNAME": "Username",
     "OLD_PASSWORD": "Confirm your old password",
     "PASSWORD": "New password"
   },


### PR DESCRIPTION
Contributes to #2523 

## What does this PR do?

Added the UI component and validation for username change when editing in profile. Requesting review from original author @nicksellen 

Updated profile view:
<img width="729" alt="image" src="https://user-images.githubusercontent.com/31333688/167222901-0b615c4c-4c3d-402c-a39a-c1c62404d6c0.png">

Wall mentions before:
<img width="710" alt="image" src="https://user-images.githubusercontent.com/31333688/167222925-85e1e69a-a653-4feb-83d2-f720a5dc5b6d.png">

Wall mentions after:
<img width="722" alt="image" src="https://user-images.githubusercontent.com/31333688/167222952-2933fb4f-c44a-4c50-aa8d-d4a53e2bf2c4.png">

Validation for trying to change to existing usernames:
<img width="714" alt="image" src="https://user-images.githubusercontent.com/31333688/167222969-dde9c40c-9695-4280-bf72-6216b0d943fc.png">

For the following request, I do not know how to approach this. If this is doable from the frontend, I believe I can contribute with some guidance. However, I suspect it would have to be approached from the backend with more complexity. Currently, it only updates to the @-mentions that exist already on the walls, chat, etc...
> If you change username, it goes through and rewrites all the posts to update it.

## Links to related issues

[#2523]

## Checklist

- [x] added a test, or explain why one is not needed/possible...
- [x] no unrelated changes
- [x] asked someone for a code review
- [x] joined [#karrot:matrix.org](https://matrix.to/#/#karrot:matrix.org)
- [x] added an entry to CHANGELOG.md (description, pull request link, username(s))
- [x] tried out on a mobile device (does everything work as expected on a smaller screen?)
