### PR TITLE
Add community banners

### DIFF
--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -3021,12 +3021,18 @@ exports[`Storyshots Banners Banners 1`] = `
   <!--[-->
   <div class="q-banner row items-center k-banner bg-secondary text-white" role="alert" style="min-height:unset;">
     <div class="q-banner__avatar col-auto row items-center self-start"><i class="q-icon fas fa-child" style="font-size:1.4em;" aria-hidden="true" role="presentation"> </i></div>
-    <div class="q-banner__content col text-body2">This is a playground group, you can&#39;t break anything. Explore, click around and have fun! </div>
+    <div class="q-banner__content col text-body2">
+      <!--[-->This is a playground group, you can&#39;t break anything. Explore, click around and have fun!
+      <!--]-->
+    </div>
     <div class="q-banner__actions row items-center justify-end col-auto"><button class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--rectangle q-btn--actionable q-focusable q-hoverable q-btn--dense" style="" tabindex="0" type="button"><span class="q-focus-helper"></span><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><span class="block">Join another group</span></span></button></div>
   </div>
   <div class="q-banner row items-center k-banner bg-warning text-white" role="alert" style="min-height:unset;">
     <div class="q-banner__avatar col-auto row items-center self-start"><i class="q-icon notranslate material-icons" style="font-size:1.4em;" aria-hidden="true" role="presentation">report_problem</i></div>
-    <div class="q-banner__content col text-body2">Offline. Press here to reconnect. </div>
+    <div class="q-banner__content col text-body2">
+      <!--[-->Offline. Press here to reconnect.
+      <!--]-->
+    </div>
     <div class="q-banner__actions row items-center justify-end col-auto"><button class="q-btn q-btn-item non-selectable no-outline q-btn--flat q-btn--rectangle q-btn--actionable q-focusable q-hoverable q-btn--dense" style="" tabindex="0" type="button"><span class="q-focus-helper"></span><span class="q-btn__content text-center col items-center q-anchor--skip justify-center row"><i class="q-icon notranslate material-icons" style="" aria-hidden="true" role="img">refresh</i></span></button></div>
   </div>
   <!--]-->

--- a/src/alerts/components/Banners.vue
+++ b/src/alerts/components/Banners.vue
@@ -2,6 +2,7 @@
   <BannersUI
     :banners="$store.getters['banners/all']"
     @reconnect="$store.dispatch('connectivity/reconnect')"
+    @dismiss-banner="id => $store.dispatch('communityFeed/dismissBanner', id)"
   />
 </template>
 

--- a/src/alerts/components/BannersUI.vue
+++ b/src/alerts/components/BannersUI.vue
@@ -1,14 +1,19 @@
 <template>
   <div>
     <QBanner
-      v-for="{ type, icon, className, action, message, context } in formattedBanners"
+      v-for="{ type, icon, className, action, message, html, context } in formattedBanners"
       :key="type"
       class="k-banner"
       style="min-height: unset"
       inline-actions
       :class="className"
     >
-      {{ $t(message, context) }}
+      <template v-if="html">
+        <div class="html" v-html="html" />
+      </template>
+      <template v-else-if="message">
+        {{ $t(message, context) }}
+      </template>
       <template #avatar>
         <QIcon
           :name="icon"
@@ -37,6 +42,8 @@ import {
   Dialog,
 } from 'quasar'
 
+import bannersAPI from '@/communityFeed/api/communityFeed'
+
 export default {
   components: {
     QBanner,
@@ -53,17 +60,37 @@ export default {
     'agree',
     'reconnect',
   ],
+  data () {
+    return {
+      communityBannerTopics: {},
+    }
+  },
   computed: {
     formattedBanners () {
       return this.banners.map(banner => {
+        const formatted = this[banner.type](banner.context)
+        if (!formatted) return null
         return {
-          ...this[banner.type](banner.context),
+          ...formatted,
           ...banner,
         }
       }).filter(banner => {
-        return !banner.desktopOnly || !this.$q.platform.is.mobile
+        return banner && (!banner.desktopOnly || !this.$q.platform.is.mobile)
       })
     },
+  },
+  async created () {
+    const communityBanners = this.banners.filter(banner => banner.type === 'communityBanner')
+    for (const banner of communityBanners) {
+      try {
+        const { topicId } = banner.context
+        // TODO: would need to not fetch dismissed ones, and all this logic really belongs in the store
+        this.communityBannerTopics[topicId] = await bannersAPI.getTopic(topicId)
+      }
+      catch (e) {
+        console.error(e)
+      }
+    }
   },
   methods: {
     awaitingAgreement (agreement) {
@@ -125,6 +152,21 @@ export default {
         },
       }
     },
+
+    communityBanner ({ topicId }) {
+      const topic = this.communityBannerTopics[topicId]
+      if (!topic) return null
+      const post = topic.postStream.posts[0]
+      return {
+        className: 'bg-blue text-white',
+        icon: 'fas fa-bullhorn',
+        html: post.cooked,
+        action: {
+          label: 'Close',
+          handler: () => this.$emit('blah'), // TODO: would have to mark it as read
+        },
+      }
+    },
   },
 }
 </script>
@@ -135,4 +177,10 @@ body.desktop .k-banner
 
 .k-banner ::v-deep(.q-banner__avatar)
   align-self: center
+
+.html
+  ::v-deep(img.emoji)
+    width: 20px
+    height: 20px
+    vertical-align: middle
 </style>

--- a/src/alerts/components/BannersUI.vue
+++ b/src/alerts/components/BannersUI.vue
@@ -138,7 +138,7 @@ export default {
         icon: 'fas fa-bullhorn',
         html,
         action: {
-          label: 'Close',
+          label: this.$t('BUTTON.CLOSE'),
           handler: () => this.$emit('dismiss-banner', id),
         },
       }

--- a/src/alerts/datastore/banners.js
+++ b/src/alerts/datastore/banners.js
@@ -11,6 +11,7 @@ export default {
       const connected = rootGetters['connectivity/connected']
       const reconnecting = rootGetters['connectivity/reconnecting']
       const updateAvailable = rootGetters['about/updateAvailable']
+      const communityBanner = rootGetters['communityFeed/banner']
 
       if (updateAvailable && !Platform.is.cordova) {
         banners.push({
@@ -42,17 +43,12 @@ export default {
         })
       }
 
-      banners.push({
-        type: 'communityBanner',
-        context: {
-          // TODO: not sure where we'd really store this number
-          // TODO: would be nicer if we can fetch all globally pinned topics, but can't find that in discourse API
-          // TODO: ... another option would be an instance configuration to specify them in .env, or in db?
-          // TODO: would also need to save when they close it somewhere...
-          topicId: 922,
-          html: '',
-        },
-      })
+      if (communityBanner) {
+        banners.push({
+          type: 'communityBanner',
+          context: communityBanner,
+        })
+      }
 
       return banners
     },

--- a/src/alerts/datastore/banners.js
+++ b/src/alerts/datastore/banners.js
@@ -42,6 +42,18 @@ export default {
         })
       }
 
+      banners.push({
+        type: 'communityBanner',
+        context: {
+          // TODO: not sure where we'd really store this number
+          // TODO: would be nicer if we can fetch all globally pinned topics, but can't find that in discourse API
+          // TODO: ... another option would be an instance configuration to specify them in .env, or in db?
+          // TODO: would also need to save when they close it somewhere...
+          topicId: 922,
+          html: '',
+        },
+      })
+
       return banners
     },
   },

--- a/src/boot/loadInitialData.js
+++ b/src/boot/loadInitialData.js
@@ -23,7 +23,10 @@ export default async function ({ app, store: datastore }) {
 
   async function fetchCommunityFeed () {
     try {
-      await datastore.dispatch('communityFeed/fetchTopics')
+      await Promise.all([
+        datastore.dispatch('communityFeed/fetchTopics'),
+        datastore.dispatch('communityFeed/fetchBanner'),
+      ])
     }
     catch (error) {
       console.warn('Could not fetch community feed topics.')

--- a/src/communityFeed/api/communityFeed.js
+++ b/src/communityFeed/api/communityFeed.js
@@ -3,6 +3,9 @@ import axios from '@/base/api/axios'
 const backend = process.env.MODE === 'cordova' ? process.env.KARROT.BACKEND : ''
 
 export default {
+  async getTopic (postId) {
+    return (await axios.get(`/community_proxy/t/${postId}.json`)).data
+  },
   async getMeta () {
     return convert((await axios.get('/api/community-feed/')).data)
   },

--- a/src/communityFeed/api/communityFeed.js
+++ b/src/communityFeed/api/communityFeed.js
@@ -3,8 +3,8 @@ import axios from '@/base/api/axios'
 const backend = process.env.MODE === 'cordova' ? process.env.KARROT.BACKEND : ''
 
 export default {
-  async getTopic (postId) {
-    return (await axios.get(`/community_proxy/t/${postId}.json`)).data
+  async getTopic (id) {
+    return (await axios.get(`/community_proxy/t/${id}.json`)).data
   },
   async getMeta () {
     return convert((await axios.get('/api/community-feed/')).data)
@@ -13,7 +13,7 @@ export default {
     return (await axios.post('/api/community-feed/mark_seen/')).data
   },
   async latestTopics () {
-    const data = (await axios.get('/community_proxy/c/karrot.json')).data
+    const data = (await axios.get('/community_proxy/c/karrot/7.json')).data
     const users = data.users
     const topics = data.topicList.topics
     return topics.map(topic => {

--- a/src/communityFeed/datastore/communityFeed.js
+++ b/src/communityFeed/datastore/communityFeed.js
@@ -1,8 +1,11 @@
 import communityFeedAPI from '@/communityFeed/api/communityFeed'
 
+const COMMUNITY_BANNER_TOPIC_ID = process.env.KARROT.BACKEND === 'https://karrot.world' ? 933 : 930
+
 function initialState () {
   return {
     topics: [],
+    banner: null,
     meta: {
       markedAt: null,
     },
@@ -17,11 +20,24 @@ export default {
       ...topic,
       isUnread: state.meta.markedAt && topic.lastPostedAt > state.meta.markedAt,
     })).sort((a, b) => b.lastPostedAt - a.lastPostedAt),
+    banner: state => state.banner,
     unreadCount: (state, getters) => getters.topics.filter(t => t.isUnread).length,
   },
   actions: {
     async fetchTopics ({ commit }) {
       commit('setTopics', await communityFeedAPI.latestTopics())
+    },
+    async fetchBanner ({ commit }) {
+      const topic = await communityFeedAPI.getTopic(COMMUNITY_BANNER_TOPIC_ID)
+      const { posts } = topic.postStream
+      posts.shift() // remove the first one, the first post in the topic is not an announcement
+      if (posts.length > 0) {
+        const post = posts[posts.length - 1]
+        const id = getDismissedBannerId()
+        if (!id || (post.id > id)) { // assuming post ids always increment...
+          commit('setBanner', { id: post.id, html: post.cooked })
+        }
+      }
     },
     async fetchMeta ({ commit }) {
       commit('setMeta', await communityFeedAPI.getMeta())
@@ -30,10 +46,17 @@ export default {
       if (!rootGetters['auth/isLoggedIn']) return
       communityFeedAPI.markSeen()
     },
+    dismissBanner ({ commit }, id) {
+      dismissBanner(id)
+      commit('setBanner', null)
+    },
   },
   mutations: {
     setTopics (state, topics) {
       state.topics = topics
+    },
+    setBanner (state, banner) {
+      state.banner = banner
     },
     setMeta (state, meta) {
       state.meta = meta
@@ -53,4 +76,20 @@ export function plugin (datastore) {
       datastore.commit('communityFeed/clearMeta')
     }
   })
+}
+
+function dismissBanner (id) {
+  if (window.localStorage) {
+    window.localStorage.setItem('dismissedBanner', JSON.stringify({ id }))
+  }
+}
+
+function getDismissedBannerId () {
+  if (window.localStorage) {
+    const item = window.localStorage.getItem('dismissedBanner')
+    if (item) {
+      return JSON.parse(item).id
+    }
+    return null
+  }
 }


### PR DESCRIPTION
Branch URL: https://add-community-banners.dev.karrot.world/#/welcome

## What does this PR do?

A concept for community banners. With Karrot Days in mind, but also usable for other things.

Most users won't see the community forum, and this allows us to make posts from the community forum show up as banner announcements in karrot.

Here's how it works:
- there is a category in the forum with two topics: [Community Announcements](https://community.karrot.world/c/karrot/community-announcements/29)
- anyone can read those, but only "Karrot Contributors" group can post there
- there is one topic for dev.karrot.world (+ local dev) and one for karrot.world
- the frontend loads the latest post and displays it as a banner
- when the user clicks _close_ it will go away, it stores the post id in local storage
- next time the page loads it'll only show a banner if it has a higher post id than the one in local storage

It looks like this:

![Screenshot 2022-06-22 at 12-29-39 Karrot - Start a group become a community](https://user-images.githubusercontent.com/31616/175018683-1de4bd34-17a0-4aef-9372-320620842d04.png)

(this is the post on karrot --> https://community.karrot.world/t/community-announcements-dev/930/7)

todo:
- [ ] decide whether to only show when logged in
- [ ] maybe don't show if there are other banners too? (or certain other ones?)

## Links to related issues

## Checklist

- [ ] added a test, or explain why one is not needed/possible...
- [ ] no unrelated changes
- [ ] asked someone for a code review
- [ ] joined [#karrot:matrix.org](https://matrix.to/#/#karrot:matrix.org)
- [ ] added an entry to CHANGELOG.md (description, pull request link, username(s))
- [ ] tried out on a mobile device (does everything work as expected on a smaller screen?)
