### PR TITLE
Add ICS token auth support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Please document your changes in this format:
 ```
 
 ## [Unreleased]
+### Added
+- password-less ICS subscription links, to support Google Calender #2555 @tiltec
+
 ### Fixed
 - show archived types in filter if activities of that type exist @nitishvijai @yatharthchhabra [#2506](https://github.com/karrot-dev/karrot-frontend/issues/2506)
 

--- a/src/activities/api/activities.js
+++ b/src/activities/api/activities.js
@@ -45,6 +45,14 @@ export default {
     })
   },
 
+  async getICSAuthToken () {
+    return (await axios.get('/api/activities/ics_token/')).data
+  },
+
+  async refreshICSAuthToken () {
+    return (await axios.post('/api/activities/ics_token_refresh/')).data
+  },
+
   async save (activity) {
     return convert((await axios.patch(`/api/activities/${activity.id}/`, convertDateToRange(activity))).data)
   },

--- a/src/activities/components/ActivityList.vue
+++ b/src/activities/components/ActivityList.vue
@@ -162,12 +162,15 @@
                 <QItemLabel caption>
                   {{ $t('ACTIVITYLIST.ICS_DIALOG.TOKEN_NOTICE') }}
                 </QItemLabel>
-                <QBtn
-                  icon="sync"
-                  class="q-mt-sm"
-                  :label="$t('ACTIVITYLIST.ICS_DIALOG.RESET_TOKEN')"
-                  @click="$store.dispatch('activities/refreshICSAuthToken')"
-                />
+                <QItemLabel>
+                  <QBtn
+                    icon="sync"
+                    size="sm"
+                    class="q-mt-sm"
+                    :label="$t('ACTIVITYLIST.ICS_DIALOG.RESET_TOKEN')"
+                    @click="$store.dispatch('activities/refreshICSAuthToken')"
+                  />
+                </QItemLabel>
               </QItemSection>
             </QItem>
           </QList>

--- a/src/activities/components/ActivityList.vue
+++ b/src/activities/components/ActivityList.vue
@@ -159,21 +159,20 @@
                     </template>
                   </QField>
                 </QItemLabel>
+                <QItemLabel caption>
+                  {{ $t('ACTIVITYLIST.ICS_DIALOG.TOKEN_NOTICE') }}
+                </QItemLabel>
+                <QBtn
+                  icon="sync"
+                  class="q-mt-sm"
+                  :label="$t('ACTIVITYLIST.ICS_DIALOG.RESET_TOKEN')"
+                  @click="$store.dispatch('activities/refreshICSAuthToken')"
+                />
               </QItemSection>
             </QItem>
           </QList>
 
-          <p class="q-mt-lg">
-            {{ $t('ACTIVITYLIST.ICS_DIALOG.REFRESH_TOKEN') }}
-            <QBtn
-              round
-              size="sm"
-              icon="sync"
-              color="primary"
-              class="q-ml-sm"
-              @click="$store.dispatch('activities/refreshICSAuthToken')"
-            />
-          </p>
+          <QInnerLoading :showing="tokenPending" />
         </template>
         <template #actions>
           <a
@@ -283,6 +282,7 @@ import {
   QBanner,
   QBtn,
   QSeparator,
+  QInnerLoading,
 } from 'quasar'
 
 const NUM_ACTIVITIES_PER_LOAD = 25
@@ -304,6 +304,7 @@ export default {
     QBanner,
     QBtn,
     QSeparator,
+    QInnerLoading,
   },
   mixins: [
     bindRoute({
@@ -339,6 +340,10 @@ export default {
     icsUrl: {
       type: String,
       default: null,
+    },
+    tokenPending: {
+      type: Boolean,
+      default: false,
     },
   },
   emits: [

--- a/src/activities/components/ActivityList.vue
+++ b/src/activities/components/ActivityList.vue
@@ -66,6 +66,7 @@
         v-model="icsDialog"
         width="500px"
         actions-align="between"
+        @show="$store.dispatch('activities/fetchICSAuthToken')"
       >
         <template #title>
           {{ $t('ACTIVITYLIST.ICS_DIALOG.TITLE') }}
@@ -161,6 +162,18 @@
               </QItemSection>
             </QItem>
           </QList>
+
+          <p class="q-mt-lg">
+            {{ $t('ACTIVITYLIST.ICS_DIALOG.REFRESH_TOKEN') }}
+            <QBtn
+              round
+              size="sm"
+              icon="sync"
+              color="primary"
+              class="q-ml-sm"
+              @click="$store.dispatch('activities/refreshICSAuthToken')"
+            />
+          </p>
         </template>
         <template #actions>
           <a

--- a/src/activities/components/PlaceActivities.vue
+++ b/src/activities/components/PlaceActivities.vue
@@ -32,6 +32,7 @@
       :pending="fetchPending"
       :activities="activities"
       :ics-url="activitiesIcsUrl"
+      :token-pending="tokenPending"
       @join="join"
       @leave="leave"
       @detail="detail"
@@ -63,6 +64,7 @@ export default {
       activities: 'activities/byActivePlace',
       activitiesIcsUrl: 'activities/icsUrlForCurrentPlace',
       fetchPending: 'activities/fetchingForCurrentGroup',
+      tokenPending: 'activities/tokenPending',
       isEditor: 'currentGroup/isEditor',
     }),
     hasNoActivities () {

--- a/src/activities/datastore/activities.js
+++ b/src/activities/datastore/activities.js
@@ -6,6 +6,7 @@ import reactiveNow from '@/utils/reactiveNow'
 function initialState () {
   return {
     entries: {},
+    ICSAuthToken: null,
   }
 }
 
@@ -51,10 +52,10 @@ export default {
       return getters.byCurrentGroup.filter(({ place }) => place && place.isActivePlace)
     },
     icsUrlForCurrentGroup: (state, getters, rootState, rootGetters) => {
-      return activities.icsUrl({ group: rootGetters['currentGroup/id'], joined: true })
+      return activities.icsUrl({ group: rootGetters['currentGroup/id'], joined: true, token: state.ICSAuthToken })
     },
     icsUrlForCurrentPlace: (state, getters, rootState, rootGetters) => {
-      return activities.icsUrl({ place: rootGetters['places/activePlaceId'], joined: true })
+      return activities.icsUrl({ place: rootGetters['places/activePlaceId'], joined: true, token: state.ICSAuthToken })
     },
     joined: (state, getters) => getters.byCurrentGroup.filter(e => e.isUserMember),
     available: (state, getters) =>
@@ -117,6 +118,12 @@ export default {
         await activities.delete(id)
         dispatch('refresh')
       },
+      async fetchICSAuthToken ({ commit }) {
+        commit('setICSAuthToken', await activities.getICSAuthToken())
+      },
+      async refreshICSAuthToken ({ commit }) {
+        commit('setICSAuthToken', await activities.refreshICSAuthToken())
+      },
     }),
     ...withMeta({
       async fetchFeedbackPossible ({ commit }, groupId) {
@@ -168,6 +175,9 @@ export default {
         Object.freeze(rest)
         state.entries = rest
       }
+    },
+    setICSAuthToken (state, token) {
+      state.ICSAuthToken = token
     },
   },
 }

--- a/src/activities/datastore/activities.js
+++ b/src/activities/datastore/activities.js
@@ -83,6 +83,9 @@ export default {
       const status = getters['meta/status']('fetchListByGroupId', `group/${currentGroupId}`)
       return status.pending
     },
+    tokenPending: (state, getters) => {
+      return getters['meta/status']('fetchICSAuthToken').pending || getters['meta/status']('refreshICSAuthToken').pending
+    },
   },
   actions: {
     ...withMeta({

--- a/src/activities/datastore/activities.spec.js
+++ b/src/activities/datastore/activities.spec.js
@@ -100,6 +100,7 @@ describe('activities', () => {
     beforeEach(() => {
       vstore.commit('activities/update', [activity1, activity2, activity3, pastActivity1, pastActivity2, startedActivity1, startedActivity2])
       vstore.commit('activityTypes/update', Object.values(activityTypes))
+      vstore.commit('activities/setICSAuthToken', 'yourSecretToken')
     })
 
     it('can enrich', async () => {
@@ -196,11 +197,11 @@ describe('activities', () => {
     })
 
     it('generates an ics url for the current group', () => {
-      expect(vstore.getters['activities/icsUrlForCurrentGroup']).toEqual('/ics?group=666&joined=true')
+      expect(vstore.getters['activities/icsUrlForCurrentGroup']).toEqual('/ics?group=666&joined=true&token=yourSecretToken')
     })
 
     it('generates an ics url for the current place', () => {
-      expect(vstore.getters['activities/icsUrlForCurrentPlace']).toEqual('/ics?place=1234&joined=true')
+      expect(vstore.getters['activities/icsUrlForCurrentPlace']).toEqual('/ics?place=1234&joined=true&token=yourSecretToken')
     })
   })
 

--- a/src/activities/pages/GroupActivities.vue
+++ b/src/activities/pages/GroupActivities.vue
@@ -7,6 +7,7 @@
       filter
       :filter-activity-types="activityTypes"
       :ics-url="activitiesIcsUrl"
+      :token-pending="tokenPending"
       @join="join"
       @leave="leave"
       @detail="detail"
@@ -66,6 +67,7 @@ export default {
       activitiesIcsUrl: 'activities/icsUrlForCurrentGroup',
       activityTypes: 'activityTypes/byCurrentGroup',
       pending: 'activities/fetchingForCurrentGroup',
+      tokenPending: 'activities/tokenPending',
       places: 'places/byCurrentGroup',
     }),
     hasNoActivities () {

--- a/src/locales/locale-en.json
+++ b/src/locales/locale-en.json
@@ -104,7 +104,8 @@
       "SUBSCRIBE_TITLE": "Subscribe",
       "SUBSCRIBE_TEXT": "Use this URL to subscribe as an ICS calendar:",
       "MORE_INFOS": "More info about ICS",
-      "REFRESH_TOKEN": "Everyone who knows your secret URL can read your activities. To avoid this, please don't share the URL with other people. If this happenend to you, click here to create a fresh secret URL and invalidate previous URLs:"
+      "TOKEN_NOTICE": "Anyone who has the secret link can access. No sign-in required.",
+      "RESET_TOKEN": "Reset secret link"
     }
   },
   "ACTIVITYMANAGE": {

--- a/src/locales/locale-en.json
+++ b/src/locales/locale-en.json
@@ -103,7 +103,8 @@
       "DOWNLOAD_BUTTON_LABEL": "Download ICS",
       "SUBSCRIBE_TITLE": "Subscribe",
       "SUBSCRIBE_TEXT": "Use this URL to subscribe as an ICS calendar:",
-      "MORE_INFOS": "More info about ICS"
+      "MORE_INFOS": "More info about ICS",
+      "REFRESH_TOKEN": "Everyone who knows your secret URL can read your activities. To avoid this, please don't share the URL with other people. If this happenend to you, click here to create a fresh secret URL and invalidate previous URLs:"
     }
   },
   "ACTIVITYMANAGE": {


### PR DESCRIPTION
First implementation that uses token auth for ICS export URLs and supports token refresh.

![image](https://user-images.githubusercontent.com/4410802/175944735-7e9189dc-02f2-4099-a0bd-00cabb9c9451.png)

At the moment, the "Download" URL also has the token appended, which is usually unnecessary because it's usually downloaded with the browser session. It however allows Karrot app users to download the ICS file, because the download is usually deferred to a browser that isn't logged in.

Requires backend PR https://github.com/karrot-dev/karrot-backend/pull/1229

Closes https://github.com/karrot-dev/karrot-frontend/issues/2541