### PR TITLE
Small improvements to public activity listing UI

### DIFF
--- a/src/groupInfo/pages/GroupPreview.vue
+++ b/src/groupInfo/pages/GroupPreview.vue
@@ -196,7 +196,7 @@
                       v-bind="getIconProps(publicActivity.activityType)"
                       class="q-pr-xs"
                     />
-                    {{ publicActivity.activityType.name }}
+                    {{ getTranslatedName(publicActivity.activityType) }}
                   </div>
                   <div>
                     <QIcon
@@ -255,7 +255,7 @@ import Markdown from '@/utils/components/Markdown'
 import RandomArt from '@/utils/components/RandomArt'
 
 const { openApplication } = useDetailService()
-const { getIconProps } = useActivityTypeHelpers()
+const { getIconProps, getTranslatedName } = useActivityTypeHelpers()
 
 const { t } = useI18n()
 

--- a/src/groupInfo/pages/GroupPreview.vue
+++ b/src/groupInfo/pages/GroupPreview.vue
@@ -107,7 +107,7 @@
       </template>
       <QCardActions
         v-if="!application"
-        class="items-start q-gutter-sm"
+        class="items-start"
       >
         <template v-if="isLoggedIn">
           <template v-if="!group.isMember">
@@ -187,28 +187,30 @@
                   class="full-width"
                   style="max-height: 80px;"
                 />
-                <QCardSection>
-                  <div
-                    class="text-subtitle1"
-                    :style="{ color: '#' + publicActivity.activityType.colour }"
+                <QItem>
+                  <QItemSection
+                    avatar
+                    style="min-width: unset;"
                   >
                     <QIcon
                       v-bind="getIconProps(publicActivity.activityType)"
                       class="q-pr-xs"
+                      :style="{ color: '#' + publicActivity.activityType.colour }"
                     />
-                    {{ getTranslatedName(publicActivity.activityType) }}
-                  </div>
-                  <div>
-                    <QIcon
-                      name="fas fa-calendar-alt"
-                      color="grey-6"
-                    />
-                    {{ $d(publicActivity.date, 'shortDateAndTime') }}
-                  </div>
-                  <hr
-                    class="bg-grey-4"
-                    style="height: 1px; border: none;"
-                  >
+                  </QItemSection>
+                  <QItemSection>
+                    <QItemLabel
+                      :style="{ color: '#' + publicActivity.activityType.colour }"
+                    >
+                      {{ getTranslatedName(publicActivity.activityType) }}
+                    </QItemLabel>
+                    <QItemLabel>
+                      {{ $d(publicActivity.date, 'shortDateAndTime') }}
+                    </QItemLabel>
+                  </QItemSection>
+                </QItem>
+                <QSeparator />
+                <QCardSection>
                   <Markdown
                     :source="publicActivity.description"
                   />
@@ -236,6 +238,9 @@ import {
   QImg,
   QInfiniteScroll,
   QSpace,
+  QItem,
+  QItemSection,
+  QItemLabel,
 } from 'quasar'
 import { computed, unref } from 'vue'
 import { useI18n } from 'vue-i18n'
@@ -312,11 +317,10 @@ async function withdraw () {
 ::v-deep(.q-banner__content)
   min-width: 200px
 
-.q-card:hover
-  border-color: $primary
-
-.q-card *
+.q-card
   overflow: hidden
+  &:hover
+    border-color: $primary
 
 .photo
   &.hasPhoto

--- a/src/groupInfo/pages/GroupPreview.vue
+++ b/src/groupInfo/pages/GroupPreview.vue
@@ -162,6 +162,9 @@
       </QCardActions>
       <template v-if="publicActivities.length > 0">
         <QSeparator />
+        <div class="text-subtitle1 q-pl-lg q-pt-lg">
+          {{ $t('ACTIVITYLIST.PUBLIC.UPCOMING_ACTIVITIES') }}
+        </div>
         <QInfiniteScroll v-bind="infiniteScroll">
           <QCardSection
             class="row public-activities"
@@ -185,16 +188,30 @@
                   style="max-height: 80px;"
                 />
                 <QCardSection>
-                  <span
+                  <div
+                    class="text-subtitle1"
                     :style="{ color: '#' + publicActivity.activityType.colour }"
                   >
                     <QIcon
                       v-bind="getIconProps(publicActivity.activityType)"
                       class="q-pr-xs"
                     />
-                  </span>
-                  {{ $d(publicActivity.date, 'shortDateAndTime') }}
-                  <Markdown :source="publicActivity.description" />
+                    {{ publicActivity.activityType.name }}
+                  </div>
+                  <div>
+                    <QIcon
+                      name="fas fa-calendar-alt"
+                      color="grey-6"
+                    />
+                    {{ $d(publicActivity.date, 'shortDateAndTime') }}
+                  </div>
+                  <hr
+                    class="bg-grey-4"
+                    style="height: 1px; border: none;"
+                  >
+                  <Markdown
+                    :source="publicActivity.description"
+                  />
                 </QCardSection>
               </QCard>
             </div>
@@ -294,6 +311,9 @@ async function withdraw () {
 
 ::v-deep(.q-banner__content)
   min-width: 200px
+
+.q-card:hover
+  border-color: $primary
 
 .q-card *
   overflow: hidden

--- a/src/locales/locale-en.json
+++ b/src/locales/locale-en.json
@@ -98,7 +98,8 @@
       "WHEN": "When",
       "WHERE": "Where",
       "SHARE": "Public activity link",
-      "VIEW": "Public View"
+      "VIEW": "Public View",
+      "UPCOMING_ACTIVITIES": "Upcoming activities"
     },
     "JOINEDNOTICE": "You have one upcoming activity | You have {count} upcoming activities",
     "NONE": "No upcoming activities",


### PR DESCRIPTION
Fixes #2602

## What does this PR do?

* "upcoming activities" heading
* show the activity type name on first line
* date on second
* a horiztonal line to divide the activity info from the activity description

![publicactivities2](https://user-images.githubusercontent.com/31616/206935097-785abcf3-6b67-4769-938a-2fe6a1606f39.png)



## Links to related issues

## Checklist

- [ ] added a test, or explain why one is not needed/possible...
- [ ] no unrelated changes
- [ ] asked someone for a code review
- [ ] joined [#karrot:matrix.org](https://matrix.to/#/#karrot:matrix.org)
- [ ] added an entry to CHANGELOG.md (description, pull request link, username(s))
- [ ] tried out on a mobile device (does everything work as expected on a smaller screen?)
