### PR TITLE
Link available activities to only show free slots

### DIFF
--- a/src/group/components/AvailableActivities.vue
+++ b/src/group/components/AvailableActivities.vue
@@ -21,7 +21,7 @@ const { groupId } = useCurrentGroupService()
 const router = useRouter()
 
 function go () {
-  router.push({ name: 'groupActivities', params: { groupId: groupId.value }, query: { place: 'subscribed' } })
+  router.push({ name: 'groupActivities', params: { groupId: groupId.value }, query: { place: 'subscribed', slots: 'free' } })
 }
 
 </script>


### PR DESCRIPTION
Fixes #2620

## What does this PR do?

As @dwaxweiler described in the issue, makes more sense to link to a view that shows activities in your favourite places that actually have free slots.

## Links to related issues

## Checklist

- [ ] added a test, or explain why one is not needed/possible...
- [ ] no unrelated changes
- [ ] asked someone for a code review
- [ ] joined [#karrot:matrix.org](https://matrix.to/#/#karrot:matrix.org)
- [ ] added an entry to CHANGELOG.md (description, pull request link, username(s))
- [ ] tried out on a mobile device (does everything work as expected on a smaller screen?)
