### PR TITLE
Ensure absolute URL paths start with /

### DIFF
--- a/src/utils/absoluteURL.js
+++ b/src/utils/absoluteURL.js
@@ -8,5 +8,6 @@
 
 export const absoluteURL = path => {
   const origin = process.env.MODE === 'cordova' ? process.env.KARROT.BACKEND : window.location.origin
+  if (!path.startsWith('/')) path = '/' + path
   return `${origin}${path}`
 }


### PR DESCRIPTION
Fixes #2618

## What does this PR do?

The public activity link was being generated with a missing `/`, which sort of worked, but I think some programs didn't recognise it as a link or something. This ensures we always generate links with that `/` in place.

## Links to related issues

## Checklist

- [ ] added a test, or explain why one is not needed/possible...
- [ ] no unrelated changes
- [ ] asked someone for a code review
- [ ] joined [#karrot:matrix.org](https://matrix.to/#/#karrot:matrix.org)
- [ ] added an entry to CHANGELOG.md (description, pull request link, username(s))
- [ ] tried out on a mobile device (does everything work as expected on a smaller screen?)
