### PR TITLE
Use updated validation API

### DIFF
--- a/src/authuser/components/Settings/ProfileEdit.vue
+++ b/src/authuser/components/Settings/ProfileEdit.vue
@@ -138,9 +138,9 @@ export default {
     displayNameError () {
       if (this.v$.edit.displayName.$error) {
         const m = this.v$.edit.displayName
-        if (!m.required) return this.$t('VALIDATION.REQUIRED')
-        if (!m.minLength) return this.$t('VALIDATION.MINLENGTH', { min: 2 })
-        if (!m.maxLength) return this.$t('VALIDATION.MAXLENGTH', { max: 81 })
+        if (m.required.$invalid) return this.$t('VALIDATION.REQUIRED')
+        if (m.minLength.$invalid) return this.$t('VALIDATION.MINLENGTH', { min: 2 })
+        if (m.maxLength.$invalid) return this.$t('VALIDATION.MAXLENGTH', { max: 81 })
       }
       return this.firstError('displayName')
     },

--- a/src/authuser/components/Signup.vue
+++ b/src/authuser/components/Signup.vue
@@ -129,9 +129,9 @@ export default {
     displayNameError () {
       if (this.v$.user.displayName.$error) {
         const m = this.v$.user.displayName
-        if (!m.required) return this.$t('VALIDATION.REQUIRED')
-        if (!m.minLength) return this.$t('VALIDATION.MINLENGTH', { min: 2 })
-        if (!m.maxLength) return this.$t('VALIDATION.MAXLENGTH', { max: 81 })
+        if (m.required.$invalid) return this.$t('VALIDATION.REQUIRED')
+        if (m.minLength.$invalid) return this.$t('VALIDATION.MINLENGTH', { min: 2 })
+        if (m.maxLength.$invalid) return this.$t('VALIDATION.MAXLENGTH', { max: 81 })
       }
       return this.firstError('displayName')
     },
@@ -141,8 +141,8 @@ export default {
     usernameError () {
       if (this.v$.user.username.$error) {
         const m = this.v$.user.username
-        if (!m.required) return this.$t('VALIDATION.REQUIRED')
-        if (!m.valid) return this.$t('VALIDATION.VALID_USERNAME')
+        if (m.required.$invalid) return this.$t('VALIDATION.REQUIRED')
+        if (m.valid.$invalid) return this.$t('VALIDATION.VALID_USERNAME')
       }
       const error = this.firstError('username')
       if (error === 'username_invalid') return this.$t('VALIDATION.VALID_USERNAME')

--- a/src/group/components/ActivityTypeForm.vue
+++ b/src/group/components/ActivityTypeForm.vue
@@ -403,8 +403,8 @@ export default {
     nameError () {
       if (this.v$.edit.name.$error) {
         const m = this.v$.edit.name
-        if (!m.required) return this.$t('VALIDATION.REQUIRED')
-        if (!m.isUnique) return this.$t('VALIDATION.UNIQUE')
+        if (m.required.$invalid) return this.$t('VALIDATION.REQUIRED')
+        if (m.isUnique.$invalid) return this.$t('VALIDATION.UNIQUE')
       }
       return this.firstError('name')
     },

--- a/src/group/components/PlaceTypeForm.vue
+++ b/src/group/components/PlaceTypeForm.vue
@@ -265,8 +265,8 @@ export default {
     nameError () {
       if (this.v$.edit.name.$error) {
         const m = this.v$.edit.name
-        if (!m.required) return this.$t('VALIDATION.REQUIRED')
-        if (!m.isUnique) return this.$t('VALIDATION.UNIQUE')
+        if (m.required.$invalid) return this.$t('VALIDATION.REQUIRED')
+        if (m.isUnique.$invalid) return this.$t('VALIDATION.UNIQUE')
       }
       return this.firstError('name')
     },


### PR DESCRIPTION
Fixes #2614

## What does this PR do?

A user struggled to sign up because they couldn't see the username had validation errors. I noticed that quite a few places were using the old vuelidate API to check for errors, so I fixed them all.

## Links to related issues

## Checklist

- [ ] added a test, or explain why one is not needed/possible...
- [ ] no unrelated changes
- [ ] asked someone for a code review
- [ ] joined [#karrot:matrix.org](https://matrix.to/#/#karrot:matrix.org)
- [ ] added an entry to CHANGELOG.md (description, pull request link, username(s))
- [ ] tried out on a mobile device (does everything work as expected on a smaller screen?)
