### PR TITLE
Don't show archived places in favourites list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Please document your changes in this format:
 ```
 
 ## [Unreleased]
+### Fixed
+- don't show archived place is sidebar favourites list @nicksellen #2629
 
 ## [10.0.1] - 2022-12-04
 ### Fixed

--- a/src/sidenav/components/SidenavPlaces.vue
+++ b/src/sidenav/components/SidenavPlaces.vue
@@ -118,7 +118,7 @@ function getUnreadWallMessageCount (place) {
   return getPlaceStatus(place.id).unreadWallMessageCount
 }
 
-const subscribedPlaces = computed(() => places.value.filter(place => place.isSubscribed))
+const subscribedPlaces = computed(() => places.value.filter(place => place.isSubscribed && place.status !== 'archived'))
 const activePlaceCount = computed(() => places.value.filter(place => place.status === 'active').length)
 </script>
 


### PR DESCRIPTION
Fixes #2628

## What does this PR do?

Filters out archived places in favourites list. There could be an argument to only show active ones, or even have a filter in the sidebar, but I opted for the simplest one that resolve the issue. I imagine getting rid of the archived ones is the most important thing right now.

## Links to related issues

## Checklist

- [ ] added a test, or explain why one is not needed/possible...
- [ ] no unrelated changes
- [ ] asked someone for a code review
- [ ] joined [#karrot:matrix.org](https://matrix.to/#/#karrot:matrix.org)
- [ ] added an entry to CHANGELOG.md (description, pull request link, username(s))
- [ ] tried out on a mobile device (does everything work as expected on a smaller screen?)
