### PR TITLE
Minor improvements to activity item UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Please document your changes in this format:
 ```
 
 ## [Unreleased]
+- minor improvements to activity item ui @nicksellen #2630
 
 ## [10.0.1] - 2022-12-04
 ### Fixed

--- a/src/activities/components/ActivityEditButton.vue
+++ b/src/activities/components/ActivityEditButton.vue
@@ -1,7 +1,6 @@
 <template>
   <QBtn
     icon="fas fa-pencil-alt"
-    color="white"
     text-color="grey-5"
     size="xs"
     round

--- a/src/activities/components/ActivityItem.vue
+++ b/src/activities/components/ActivityItem.vue
@@ -252,13 +252,14 @@
         flat
         no-caps
         :to="{ name: 'publicActivity', params: { activityPublicId: activity.publicId } }"
+        :padding="$q.platform.is.mobile ? '4px' : undefined"
       >
         <QIcon
           name="fas fa-globe"
           size="xs"
           class="q-mr-sm"
         />
-        {{ $t('ACTIVITYLIST.PUBLIC.VIEW') }}
+        <span v-if="!$q.platform.is.mobile">{{ $t('ACTIVITYLIST.PUBLIC.VIEW') }}</span>
       </QBtn>
       <QSpace />
       <QBtn
@@ -269,6 +270,7 @@
         type="a"
         color="secondary"
         class="action-button"
+        :padding="$q.platform.is.mobile ? '4px' : undefined"
       >
         <template #default>
           <QIcon
@@ -276,7 +278,7 @@
             size="xs"
             class="q-mr-xs"
           />
-          <span>{{ $t('ACTIVITYLIST.ITEM.DOWNLOAD_ICS') }}</span>
+          <span v-if="!$q.platform.is.mobile">{{ $t('ACTIVITYLIST.ITEM.DOWNLOAD_ICS') }}</span>
         </template>
       </QBtn>
       <QBtn


### PR DESCRIPTION
## What does this PR do?

Two subjective design tweaks:

1. on mobile, only show icons for public link and ICS download, so the buttons don't wrap onto multiple lines
2. make the background of the edit button transparent

Before:

![wrappingbuttons](https://user-images.githubusercontent.com/31616/207741751-3a4ac2e4-1d16-408d-a629-1c8a79dabc81.png)

After:

![nonwrappingbuttons](https://user-images.githubusercontent.com/31616/207741767-0d5db701-4567-4f12-bf58-92462b5aeac0.png)


## Links to related issues

## Checklist

- [ ] added a test, or explain why one is not needed/possible...
- [ ] no unrelated changes
- [ ] asked someone for a code review
- [ ] joined [#karrot:matrix.org](https://matrix.to/#/#karrot:matrix.org)
- [ ] added an entry to CHANGELOG.md (description, pull request link, username(s))
- [ ] tried out on a mobile device (does everything work as expected on a smaller screen?)
