### PR TITLE
Fix sometimes not getting latest messages

### DIFF
--- a/src/messages/services.js
+++ b/src/messages/services.js
@@ -16,6 +16,7 @@ import {
 } from '@/messages/queries'
 import { useUserService } from '@/users/services'
 import { defineService } from '@/utils/datastore/helpers'
+import { isNil } from '@/utils/utils'
 
 export function useThreadDetail (messageId) {
   const order = 'oldest-first'
@@ -100,7 +101,13 @@ export function useConversationAndMessages (conversationQueryParams, { order } =
     { keepPreviousData: true },
   )
 
-  const conversationId = computed(() => conversation.value?.id)
+  const hasParam = computed(() => Object.keys(conversationQueryParams).some(param => !isNil(unref(conversationQueryParams[param]))))
+
+  // We only pass through the conversationId if we actually have a param set, otherwise because we use keepPreviousData (I think) we leave
+  // the conversationId hanging around, and then vue-query can't do the re-fetching needed for the messages as it doesn't see it needs refreshing
+  // if you re-open the same conversation
+  // See https://github.com/karrot-dev/karrot-frontend/issues/2613
+  const conversationId = computed(() => hasParam.value && conversation.value?.id)
 
   const {
     messages,

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -58,6 +58,11 @@ export function isObject (x) {
     !(x instanceof Date)
 }
 
+// True if it's undefined or null, otherwise false
+export function isNil (val) {
+  return typeof val === 'undefined' || val === null
+}
+
 // Just enough to support the keys we get back from the Django API
 export function camelize (val) {
   return val.replace(/_(.)/g, (_, s) => s.toUpperCase())


### PR DESCRIPTION
Fixes #2613

## What does this PR do?

I had seen a number of times new messages in the "latest messages" drop down, but when I clicked on the message to open the conversation view, the latest message I had seen in the dropdown wasn't loaded in the conversation.

What I _think_ was happening is:
- websocket connection dropped or was interupted
- new message is sent elsewhere, but not received via websocket
- the "latest messages" dropdown reloads fresh when you open it, so you could see latest message
- detail view conversation does not refresh if you open the same conversation as you did last time

So, seems quite specific case, but I saw it with my own eyes many times. Hopefully I have diagnosed and fixed what is happening, but maybe not!

At the code level the problem is that we use "keepPreviousData" for the main conversation info, which prevents a loading flash when switching conversations, but when closing the detail we still have the conversation and messages loaded, so when you open it again, it doesn't get registered as a reload and thus doesn't trigger vue-query to reload...

I still keep the conversation with "keepPreviousData" to prevent flash, but now only pass that down to the messages query if we actually have an active detail parameter set (which are cleared when you close the detail), so re-opening it means the messages queries _sees_ a change, and can refresh.

## Links to related issues

## Checklist

- [ ] added a test, or explain why one is not needed/possible...
- [x] no unrelated changes
- [ ] asked someone for a code review
- [x] joined [#karrot:matrix.org](https://matrix.to/#/#karrot:matrix.org)
- [ ] added an entry to CHANGELOG.md (description, pull request link, username(s))
- [ ] tried out on a mobile device (does everything work as expected on a smaller screen?)
