### PR TITLE
Disable sentry session tracking

### DIFF
--- a/src/utils/sentry.js
+++ b/src/utils/sentry.js
@@ -9,6 +9,11 @@ export function configureSentry (app, { dsn, environment }) {
     dsn,
     environment,
     release: process.env.KARROT.GIT_SHA1,
+
+    // Disable sentry session tracking
+    // See https://docs.sentry.io/platforms/javascript/configuration/releases/?original_referrer=https%3A%2F%2Fwww.startpage.com%2F#sessions
+    // and https://community.karrot.world/t/sending-too-much-data-to-sentry/1194
+    autoSessionTracking: false,
     ignoreErrors: [
       'ResizeObserver loop limit exceeded', // Chrome
       'ResizeObserver loop completed with undelivered notifications', // Firefox


### PR DESCRIPTION
Closes https://community.karrot.world/t/sending-too-much-data-to-sentry/1194

## What does this PR do?

I noticed on each page change sentry was sending data such as:

```
{"sent_at":"2023-06-01T08:03:27.301Z","sdk":{"name":"sentry.javascript.vue","version":"7.50.0"}}
{"type":"session"}
{"sid":"184884223cbc450f8211537dece036a4","init":false,"started":"2023-06-01T08:03:24.339Z","timestamp":"2023-06-01T08:03:27.301Z","status":"exited","errors":0,"attrs":{"release":"b7b00c3d7aebb91a6e13024c4813718aa85394ac","environment":"karrot-dev","user_agent":"Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/112.0"}}
```

Our intention with sentry was to capture error information, not info on every page load, this feels invasive to me.

## Links to related issues

## Checklist

- [ ] added a test, or explain why one is not needed/possible...
- [ ] no unrelated changes
- [ ] asked someone for a code review
- [ ] joined [#karrot:matrix.org](https://matrix.to/#/#karrot:matrix.org)
- [ ] added an entry to CHANGELOG.md (description, pull request link, username(s))
- [ ] tried out on a mobile device (does everything work as expected on a smaller screen?)
