### PR TITLE
Use new FORUM_* config from API

### DIFF
--- a/src/communityFeed/api/communityFeed.js
+++ b/src/communityFeed/api/communityFeed.js
@@ -12,8 +12,8 @@ export default {
   async markSeen () {
     return (await axios.post('/api/community-feed/mark_seen/')).data
   },
-  async latestTopics () {
-    const data = (await axios.get('/community_proxy/latest.json')).data
+  async latestTopics (feed) {
+    const data = (await axios.get(`/community_proxy/${feed}`)).data
     const users = data.users
     const topics = data.topicList.topics
     return topics.map(topic => {

--- a/src/communityFeed/queries.js
+++ b/src/communityFeed/queries.js
@@ -4,17 +4,17 @@ import { useQuery } from 'vue-query'
 import api from '@/communityFeed/api/communityFeed'
 
 export const QUERY_KEY_BASE = 'communityFeed'
-export const queryKeyCommunityFeed = () => [QUERY_KEY_BASE, 'feed']
+export const queryKeyCommunityFeed = feed => [QUERY_KEY_BASE, 'feed', feed]
 export const queryKeyCommunityFeedMeta = () => [QUERY_KEY_BASE, 'feed-meta']
 export const queryKeyCommunityTopic = topicId => [QUERY_KEY_BASE, 'topic', topicId]
 
-export function useCommunityFeedQuery (queryOptions = {}) {
+export function useCommunityFeedQuery ({ feed }) {
   const query = useQuery(
-    queryKeyCommunityFeed(),
-    () => api.latestTopics().catch(() => ([])),
+    queryKeyCommunityFeed(feed),
+    () => api.latestTopics(unref(feed)).catch(() => ([])),
     {
       placeholderData: () => [],
-      ...queryOptions,
+      enabled: computed(() => Boolean(unref(feed))),
     },
   )
 

--- a/src/communityFeed/services.js
+++ b/src/communityFeed/services.js
@@ -1,14 +1,17 @@
 import { ref, computed } from 'vue'
 
 import { useAuthService } from '@/authuser/services'
+import { useConfigQuery } from '@/base/queries'
 import { useCommunityFeedMetaQuery, useCommunityFeedQuery, useCommunityTopicQuery } from '@/communityFeed/queries'
 import { defineService } from '@/utils/datastore/helpers'
 
 export const useCommunityFeedService = defineService(() => {
   const { isLoggedIn } = useAuthService()
+  const { config } = useConfigQuery()
+  const discussionsFeed = computed(() => isLoggedIn.value && config.value?.forum?.discussionsFeed)
   const {
     latestTopics,
-  } = useCommunityFeedQuery({ enabled: isLoggedIn })
+  } = useCommunityFeedQuery({ feed: discussionsFeed })
 
   const {
     meta,
@@ -33,10 +36,11 @@ export const useCommunityFeedService = defineService(() => {
 })
 
 export const useCommunityBannerService = defineService(() => {
-// Magic topics on community.karrot.world forum that we use for banner updates
-  const topicId = process.env.KARROT.BACKEND === 'https://karrot.world' ? 933 : 930
+  const { config } = useConfigQuery()
 
-  const { topic } = useCommunityTopicQuery({ topicId })
+  const bannerTopicId = computed(() => config.value?.forum?.bannerTopicId)
+
+  const { topic } = useCommunityTopicQuery({ topicId: bannerTopicId })
 
   const dismissedBannerId = ref(getDismissedBannerIdFromLocalStorage())
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -86,7 +86,7 @@ export async function withDefaults (options = {}) {
       // for some reason I have to include the router here or some tests don't
       // have access to routes, etc...
       // It causes a warning for other tests though: "App already provides property with key "Symbol(router)"
-      router,
+      ...(router ? [router] : []),
       [Quasar, quasarConfig],
       [VueQueryPlugin, { queryClient }],
       i18nPlugin,

--- a/test/mockBackend/config.js
+++ b/test/mockBackend/config.js
@@ -4,5 +4,7 @@ export function createMockConfigBackend () {
   // Just a stub so we don't have errors
   get('/api/config/', () => {
     return [200, {}]
+  }, {
+    requireAuth: false,
   })
 }


### PR DESCRIPTION
## What does this PR do?

Something broke in the frontend build so that it loaded the dev banner topic for dev and prod, I decided it makes more sense to use the server API config endpoint, so we can configure it using .env file on server, not have it baked in. Which further moves us to have a more generic frontend build, not one that requires build-time variables.

It uses the newly added FORUM_* config options that the API returns for:
- banner topic (default is 930)
- discussions feed (default is `latest.json`, but you can configure it for a single category, e.g. `c/feedback-ideas/31.json` -- so long as it has the same json structure as the other feeds (compared to `latest.json`))