### PR TITLE
Add screenshare and mini participant view

### DIFF
--- a/src/meet/components/MeetButton.vue
+++ b/src/meet/components/MeetButton.vue
@@ -6,6 +6,7 @@
     v-bind="sidenav ? {flat: true, dense: true} : {}"
     :class="{ 'no-margin': sidenav, 'pulsate': roomActive }"
     :style="style"
+    :disable="active"
     @click="joinRoom(subject)"
   >
     <template v-if="roomActive">
@@ -57,7 +58,7 @@ const props = defineProps({
 
 const endpoint = useLivekitEndpoint()
 const hasMeet = useHasFeature('meet')
-const { joinRoom } = useRoomService()
+const { active, joinRoom } = useRoomService()
 
 const { rooms } = useRoomListQuery()
 const { getUserById } = useUserService()

--- a/src/meet/components/Meeting.vue
+++ b/src/meet/components/Meeting.vue
@@ -1,7 +1,10 @@
 <template>
+  <MiniParticipant v-if="mini" />
   <QDialog
     maximized
+    style="z-index: 10000"
     persistent
+    :class="mini ? 'hidden' : ''"
     :model-value="true"
     @hide.stop.prevent="leave()"
   >
@@ -11,6 +14,13 @@
         class="absolute-full text-white z-top flex flex-center"
       >
         <KSpinner />
+      </div>
+
+      <div
+        v-if="screenshareParticipant"
+        class="absolute-full z-top bg-red"
+      >
+        <ScreenShare :participant="screenshareParticipant" />
       </div>
       <QCardSection
         class="full-height overflow-hidden participants-section"
@@ -40,6 +50,7 @@
     </QCard>
   </QDialog>
   <QDialog
+    style="z-index: 20000"
     :model-value="true"
     seamless
     position="bottom"
@@ -60,38 +71,33 @@
         ref="toolbar"
         class="row items-center no-wrap justify-between"
       >
-        <template v-if="true">
-          <QBtn
-            :icon="videoEnabled ? 'videocam' : 'videocam_off'"
-            round
-            :color="videoEnabled ? 'green' : 'white'"
-            :text-color="videoEnabled ? 'white' : 'grey'"
-            @click="videoEnabled = !videoEnabled"
-          />
-          <QBtn
-            :icon="audioEnabled ? 'fas fa-microphone' : 'fas fa-microphone-slash'"
-            round
-            :color="audioEnabled ? 'green' : 'white'"
-            :text-color="audioEnabled ? 'white' : 'grey'"
-            @click="audioEnabled = !audioEnabled"
-          />
-        </template>
-        <template v-else>
-          <QToggle
-            v-model="videoEnabled"
-            icon="videocam"
-            size="lg"
-          />
-          <QToggle
-            v-model="audioEnabled"
-            icon="fas fa-microphone"
-            size="lg"
-          />
-        </template>
+        <QBtn
+          :icon="videoEnabled ? 'videocam' : 'videocam_off'"
+          round
+          :color="videoEnabled ? 'green' : 'white'"
+          :text-color="videoEnabled ? 'white' : 'grey'"
+          @click="videoEnabled = !videoEnabled"
+        />
+        <QBtn
+          :icon="audioEnabled ? 'fas fa-microphone' : 'fas fa-microphone-slash'"
+          round
+          :color="audioEnabled ? 'green' : 'white'"
+          :text-color="audioEnabled ? 'white' : 'grey'"
+          @click="audioEnabled = !audioEnabled"
+        />
+        <QBtn
+          size="md"
+          round
+          icon="screen_share"
+          :color="screenshare ? 'green' : 'white'"
+          :text-color="screenshare ? 'white' : 'grey'"
+          @click="screenshare = !screenshare"
+        />
         <QBtn
           flat
           size="md"
           icon="fas fa-cog"
+          round
           color="primary"
           :disable="!optionsEnabled"
           @click="showOptions = !showOptions"
@@ -118,19 +124,30 @@
             />
           </QMenu>
         </QBtn>
+        <QBtn
+          no-caps
+          dense
+          :icon="mini ? 'fas fa-expand-alt' : 'fas fa-compress-alt'"
+          text-color="grey"
+          unelevated
+          size="sm"
+          @click="mini = !mini"
+        />
       </QCardSection>
     </QCard>
   </QDialog>
 </template>
 
 <script setup>
-import { QBtn, QDialog, QCard, QCardSection, QSeparator, QToggle, QMenu } from 'quasar'
-import { computed, onMounted, ref } from 'vue'
+import { QBtn, QDialog, QCard, QCardSection, QSeparator, QMenu } from 'quasar'
+import { computed, onMounted, ref, watch } from 'vue'
 
 import { useMediaDeviceService, useRoomService, useTrackPublisher } from '@/meet/helpers'
 
 import AudioDeviceSelect from '@/meet/components/AudioDeviceSelect.vue'
+import MiniParticipant from '@/meet/components/MiniParticipant.vue'
 import Participant from '@/meet/components/Participant.vue'
+import ScreenShare from '@/meet/components/ScreenShare.vue'
 import VideoDeviceSelect from '@/meet/components/VideoDeviceSelect.vue'
 import KSpinner from '@/utils/components/KSpinner.vue'
 
@@ -141,6 +158,9 @@ const toolbarHeight = computed(() => toolbar.value?.$el?.offsetHeight ?? 0)
 
 const showOptions = ref(false)
 const optionsEnabled = computed(() => (videoEnabled.value && videoDevices.value?.length > 0) || (audioEnabled.value && audioDevices.value?.length > 0))
+
+const mini = ref(true)
+const screenshare = ref(false)
 
 const {
   enable,
@@ -159,7 +179,20 @@ const emit = defineEmits([
 
 const { leaveRoom, room, participants } = useRoomService()
 
+watch(screenshare, enabled => {
+  room.value.localParticipant.setScreenShareEnabled(enabled)
+})
+
 const oneParticipant = computed(() => participants.value?.length === 1)
+
+const screenshareParticipant = computed(() => participants.value.find(participant => participant.screenShareVideoMediaStreamTrack))
+
+watch(screenshareParticipant, value => {
+  if (value) {
+    // Auto-switch them into full view if we have a screensharer
+    mini.value = false
+  }
+})
 
 onMounted(() => enable())
 

--- a/src/meet/components/MiniParticipant.vue
+++ b/src/meet/components/MiniParticipant.vue
@@ -1,0 +1,108 @@
+<template>
+  <div
+    v-if="hasVideo"
+    ref="el"
+    class="fixed-top-right shadow-3"
+    style="width: 120px; height: 120px; z-index: 20000; border-radius: 999999px; overflow: hidden; touch-action: none;"
+    :style="left && top ? { left, top, cursor } : { top: '12px', right: '12px', cursor }"
+  >
+    <video
+      ref="videoRef"
+      class="fit no-pointer-events"
+      style="object-fit: cover;"
+    />
+  </div>
+</template>
+
+<script setup>
+import { useEventListener } from '@vueuse/core'
+import { attachToElement } from 'livekit-client'
+import { computed, ref, watch } from 'vue'
+
+import { useRoomService } from '@/meet/helpers'
+
+const el = ref(null)
+const videoRef = ref(null)
+
+const participant = ref(null)
+
+const { participants } = useRoomService()
+
+watch(participants, entries => {
+  // Find the first one speaking
+  const speakingParticipant = entries.find(participant => participant.isSpeaking)
+  if (speakingParticipant) {
+    participant.value = speakingParticipant
+  }
+  else if (!participant.value) {
+    // Or if we don't have one just pick the first one
+    participant.value = participants.value[0]
+  }
+}, { immediate: true })
+
+const videoMediaStreamTrack = computed(() => participant.value?.videoMediaStreamTrack)
+
+const hasVideo = computed(() => Boolean(videoMediaStreamTrack.value))
+
+watch([videoMediaStreamTrack, videoRef], ([track, element]) => {
+  if (!track || !element) return
+  attachToElement(track, element)
+})
+
+function getCursorXY (event) {
+  const { clientX: x, clientY: y } = event.touches?.[0] ?? event
+  return { x, y }
+}
+
+const left = ref(null)
+const top = ref(null)
+const cursor = ref('grab')
+
+function handleDrag (event) {
+  // Ignore right-clicks
+  if (event.type === 'mousedown' && event.button !== 0) return
+  const { x: initialX, y: initialY } = getCursorXY(event)
+  const style = getComputedStyle(event.target)
+  const elementX = parseInt(style.left)
+  const elementY = parseInt(style.top)
+
+  const moveEvent = {
+    touchstart: 'touchmove',
+    mousedown: 'mousemove',
+  }[event.type]
+
+  const endEvent = {
+    touchstart: 'touchend',
+    mousedown: 'mouseup',
+  }[event.type]
+
+  if (!moveEvent || !endEvent) return
+
+  event.preventDefault()
+  event.stopPropagation()
+
+  cursor.value = 'grabbing'
+
+  const moveUnlisten = useEventListener(moveEvent, event => {
+    event.preventDefault()
+    event.stopPropagation()
+    const { x, y } = getCursorXY(event)
+    const deltaX = x - initialX
+    const deltaY = y - initialY
+    left.value = `${elementX + deltaX}px`
+    top.value = `${elementY + deltaY}px`
+  })
+  const endUnlisten = useEventListener(endEvent, () => {
+    cursor.value = 'grab'
+    moveUnlisten()
+    endUnlisten()
+  })
+}
+
+useEventListener(el, 'mousedown', handleDrag)
+useEventListener(el, 'touchstart', handleDrag)
+</script>
+
+<style scoped lang="sass">
+
+</style>

--- a/src/meet/components/ScreenShare.vue
+++ b/src/meet/components/ScreenShare.vue
@@ -1,0 +1,36 @@
+<template>
+  <video
+    v-if="hasScreenShareVideo"
+    ref="videoRef"
+    class="fit bg-black"
+    style="object-fit: contain;"
+  />
+</template>
+
+<script setup>
+import { attachToElement } from 'livekit-client'
+import { computed, ref, toRef, watch } from 'vue'
+
+const videoRef = ref(null)
+
+const props = defineProps({
+  participant: {
+    type: Object,
+    required: true,
+  },
+})
+
+const participant = toRef(props, 'participant')
+
+const screenShareVideoMediaStreamTrack = computed(() => participant.value?.screenShareVideoMediaStreamTrack)
+
+const hasScreenShareVideo = computed(() => Boolean(screenShareVideoMediaStreamTrack.value))
+
+watch([screenShareVideoMediaStreamTrack, videoRef], ([track, element]) => {
+  if (!track || !element) return
+  attachToElement(track, element)
+})
+</script>
+
+<style scoped lang="sass">
+</style>

--- a/src/meet/helpers.js
+++ b/src/meet/helpers.js
@@ -261,8 +261,8 @@ export const useRoomService = defineService(() => {
       }
       const participantInfo = participantsByIdentity.value[participant.identity]
       const { identity, isLocal, audioLevel = 0, isSpeaking, connectionQuality } = participant
-      function getMediaStreamTrack (kind) {
-        const track = participant.getTracks().find(track => track.kind === kind)
+      function getMediaStreamTrack (kind, source) {
+        const track = participant.getTracks().find(track => track.kind === kind && track.source === source)
         if (!track || track.isMuted || !track.isSubscribed) return
         return track.track?.mediaStream.getTracks().find(t => t.kind === kind)
       }
@@ -274,8 +274,9 @@ export const useRoomService = defineService(() => {
         audioLevel,
         isSpeaking,
         connectionQuality,
-        videoMediaStreamTrack: getMediaStreamTrack('video') ?? null,
-        audioMediaStreamTrack: getMediaStreamTrack('audio') ?? null,
+        videoMediaStreamTrack: getMediaStreamTrack('video', 'camera') ?? null,
+        audioMediaStreamTrack: getMediaStreamTrack('audio', 'microphone') ?? null,
+        screenShareVideoMediaStreamTrack: getMediaStreamTrack('video', 'screen_share') ?? null,
       })
       return participantInfo
     }

--- a/src/utils/datastore/helpers.js
+++ b/src/utils/datastore/helpers.js
@@ -19,6 +19,7 @@ export function indexById (iterable) {
 }
 
 export function indexBy (iterable, key) {
+  if (!iterable) return {}
   return iterable.reduce((acc, cur, i) => {
     acc[cur[key]] = cur
     return acc


### PR DESCRIPTION
Adds two features to video calls:
- screensharing
- mini view, so you can still use the rest of Karrot whilst in a call

Screenshare:

![image](https://github.com/karrot-dev/karrot-frontend/assets/31616/6f18eccc-218b-4138-a353-a6008b33f530)

Mini view:

![image](https://github.com/karrot-dev/karrot-frontend/assets/31616/0337d2b0-5d04-47ff-b749-a9896e9a066d)
