### PR TITLE
Increase default activity page size to 20

### DIFF
--- a/src/activities/queries.js
+++ b/src/activities/queries.js
@@ -106,7 +106,7 @@ export function useActivityListQuery ({
   feedbackPossible,
   hasFeedback,
   ordering,
-  pageSize = 10,
+  pageSize = 20,
 }, queryOptions = {}) {
   const query = useInfiniteQuery(
     queryKeyActivityList({ groupId, placeId, placeStatus, placeArchived, seriesId, activityTypeId, slots, feedbackPossible, hasFeedback, places, ordering, dateMin }),


### PR DESCRIPTION
This is not a full fix, but slightly improves the situation for now.

The problem is that we order activities by a column that is not unique-enough, see this discussion https://github.com/encode/django-rest-framework/discussions/7888